### PR TITLE
Development environment fixes

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 mod arguments;
-use anyhow::{anyhow, bail, Context, Result};
+use anyhow::{Context, Result, anyhow, bail};
 use arguments::Arguments;
 use ariadne::{Cache, Label, Report, ReportKind, Source};
 use clap::Parser as _;
@@ -17,14 +17,13 @@ use type_sitter::Node as _;
 use crate::arguments::Commands;
 
 use interpreter::{
-    build_prelude,
+    ExecutionContext, ExecutionFileCache, ImString, LogMessage, Parser, RuntimeLog,
+    SourceReference, StackScope, StackTrace, Store, build_prelude,
     compile::{compile, iter_raw_nodes},
     execute_expression,
     execution::values::BuiltinCallableDatabase,
     new_parser, run_file,
     values::{Object, Style, Value},
-    ExecutionContext, ExecutionFileCache, ImString, LogMessage, Parser, RuntimeLog,
-    SourceReference, StackScope, StackTrace, Store,
 };
 
 fn main() {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 mod arguments;
-use anyhow::{Context, Result, anyhow, bail};
+use anyhow::{anyhow, bail, Context, Result};
 use arguments::Arguments;
 use ariadne::{Cache, Label, Report, ReportKind, Source};
 use clap::Parser as _;
@@ -17,13 +17,14 @@ use type_sitter::Node as _;
 use crate::arguments::Commands;
 
 use interpreter::{
-    ExecutionContext, ExecutionFileCache, ImString, LogMessage, Parser, RuntimeLog,
-    SourceReference, StackScope, StackTrace, Store, build_prelude,
+    build_prelude,
     compile::{compile, iter_raw_nodes},
     execute_expression,
     execution::values::BuiltinCallableDatabase,
     new_parser, run_file,
     values::{Object, Style, Value},
+    ExecutionContext, ExecutionFileCache, ImString, LogMessage, Parser, RuntimeLog,
+    SourceReference, StackScope, StackTrace, Store,
 };
 
 fn main() {
@@ -246,7 +247,7 @@ fn build_syntax_errors<'t>(
     if has_syntax_issues {
         Some(report_builder.finish())
     } else {
-        Option::None
+        None
     }
 }
 

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "crane": {
       "locked": {
-        "lastModified": 1767461147,
-        "narHash": "sha256-TH/xTeq/RI+DOzo+c+4F431eVuBpYVwQwBxzURe7kcI=",
+        "lastModified": 1771438068,
+        "narHash": "sha256-nGBbXvEZVe/egCPVPFcu89RFtd8Rf6J+4RFoVCFec0A=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "7d59256814085fd9666a2ae3e774dc5ee216b630",
+        "rev": "b5090e53e9d68c523a4bb9ad42b4737ee6747597",
         "type": "github"
       },
       "original": {
@@ -23,15 +23,16 @@
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1767596244,
-        "narHash": "sha256-P4NRZUjYbeuzv4hGrXxfdg0QpdGVoeNn0CMmzIyr398=",
+        "lastModified": 1771385326,
+        "narHash": "sha256-SI3IR8gdoIL21Ur7yfLY1Wd7MC48iqsthY0Adxzb/Bg=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "eedfb5a27900e82ec0390acc83d4d226ce86e714",
+        "rev": "6ef197384c418654c34d2819d06a80f660881486",
         "type": "github"
       },
       "original": {
         "owner": "nix-community",
+        "ref": "eureka-cpu/rust-analyzer-wrapped",
         "repo": "fenix",
         "type": "github"
       }
@@ -56,11 +57,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1767379071,
-        "narHash": "sha256-EgE0pxsrW9jp9YFMkHL9JMXxcqi/OoumPJYwf+Okucw=",
+        "lastModified": 1771369470,
+        "narHash": "sha256-0NBlEBKkN3lufyvFegY4TYv5mCNHbi5OmBDrzihbBMQ=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "fb7944c166a3b630f177938e478f0378e64ce108",
+        "rev": "0182a361324364ae3f436a63005877674cf45efb",
         "type": "github"
       },
       "original": {
@@ -81,11 +82,11 @@
     "rust-analyzer-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1767551763,
-        "narHash": "sha256-lcA/e3++3aZQSj6xCsBi2VpYyC3Q+oO/oukgfHiL+Ts=",
+        "lastModified": 1771264911,
+        "narHash": "sha256-vDNZ6Y1M3DSa1JbPGgqtdJPl4rMzxebUK9hmZcopxX0=",
         "owner": "rust-lang",
         "repo": "rust-analyzer",
-        "rev": "6a1246b69ca761480b9278df019f717b549cface",
+        "rev": "3360aebb35a099ff4a7bbd37e9a0dd44b8f23748",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -6,7 +6,8 @@
     flake-utils.url  = "github:numtide/flake-utils";
     crane.url = "github:ipetkov/crane";
     fenix = {
-      url = "github:nix-community/fenix";
+      # url = "github:nix-community/fenix";
+      url = "github:nix-community/fenix?ref=eureka-cpu/rust-analyzer-wrapped";
       inputs.nixpkgs.follows = "nixpkgs";
     };
   };
@@ -25,8 +26,15 @@
           inherit system;
         };
         fenix-pkgs = fenix.packages.${system};
-        fenix-channel = (fenix-pkgs.stable);
-	
+        fenix-channel = fenix-pkgs.stable;
+        fenix-toolchain = fenix-channel.withComponents [
+          "cargo"
+          "clippy"
+          "rust-src"
+          "rustc"
+          "rustfmt"
+          "rust-analyzer"
+        ];
         craneLib = (crane.mkLib pkgs).overrideScope (final: prev: {
           cargo = fenix-channel.cargo;
           rustc = fenix-channel.rustc;
@@ -53,11 +61,7 @@
 	    bashInteractive
 	    nodejs_24
             tree-sitter
-            fenix-pkgs.rust-analyzer
-            fenix-channel.rustfmt
-            fenix-channel.rustc
-            fenix-channel.cargo
-            fenix-channel.clippy
+            fenix-toolchain
             cargo-expand
             openssl
 	    pkg-config

--- a/interpreter/src/compile/expressions.rs
+++ b/interpreter/src/compile/expressions.rs
@@ -2053,6 +2053,7 @@ mod test {
                                         }
                                     }
                                 }],
+                                #[allow(clippy::single_range_in_vec_init)]
                                 compute_groups: vec![0..1]
                             }
                         }
@@ -2169,6 +2170,7 @@ mod test {
                                         }
                                     }
                                 }],
+                                #[allow(clippy::single_range_in_vec_init)]
                                 compute_groups: vec![0..1]
                             }
                         }
@@ -2243,6 +2245,7 @@ mod test {
                                     }
                                 }
                             ],
+                            #[allow(clippy::single_range_in_vec_init)]
                             compute_groups: vec![0..2],
                             expression: AstNode {
                                 reference: expression.reference.clone(),

--- a/interpreter/src/compile/expressions.rs
+++ b/interpreter/src/compile/expressions.rs
@@ -1038,7 +1038,7 @@ impl<'t> Parse<'t, nodes::StructDefinition<'t>> for StructDefinition {
                     nodes::anon_unions::Comma_StructMember_VaradicDots::VaradicDots(_) => true,
                 }
             }
-            Option::None => false,
+            None => false,
         };
 
         Ok(AstNode::new(file, &value, Self { members, variadic }))

--- a/interpreter/src/compile/mod.rs
+++ b/interpreter/src/compile/mod.rs
@@ -373,7 +373,7 @@ pub fn iter_raw_nodes<'t>(tree: &'t RootTree) -> impl Iterator<Item = UntypedNod
             loop {
                 if !cursor.goto_parent() {
                     // We have reached the root. We are done iterating.
-                    return Option::None;
+                    return None;
                 }
                 if cursor.goto_next_sibling() {
                     return Some(node);

--- a/interpreter/src/execution/standard_environment.rs
+++ b/interpreter/src/execution/standard_environment.rs
@@ -158,7 +158,7 @@ fn build_dimension_types(
     let types: HashMap<ImString, Value> = HashMap::from_iter(
         units::list_named_dimensions()
             .map(|(name, dimension)| (name, Some(dimension)))
-            .chain([("Any", Option::None)])
+            .chain([("Any", None)])
             .map(move |(name, dimension)| (name.into(), type_builder(dimension).into())),
     );
 

--- a/interpreter/src/execution/values/constraint_set.rs
+++ b/interpreter/src/execution/values/constraint_set.rs
@@ -363,7 +363,7 @@ impl ConstraintSet {
         };
 
         let mut m = Model::default();
-        let mut dimension = Option::None;
+        let mut dimension = None;
 
         let mut variables = HashMap::new();
 

--- a/interpreter/src/execution/values/integer.rs
+++ b/interpreter/src/execution/values/integer.rs
@@ -884,7 +884,7 @@ where
                     index = index.decrement();
                     Some(Integer(value).into())
                 } else {
-                    Option::None
+                    None
                 }
             });
 
@@ -896,7 +896,7 @@ where
                     index = index.increment();
                     Some(Integer(value).into())
                 } else {
-                    Option::None
+                    None
                 }
             });
 

--- a/interpreter/src/execution/values/iterators.rs
+++ b/interpreter/src/execution/values/iterators.rs
@@ -277,7 +277,7 @@ impl IteratorStage {
                                 let list = List::from_iter(context, buffer);
                                 Some(Ok(list.into()))
                             } else {
-                                Option::None
+                                None
                             }
                         }
                         Err(error) => Some(Err(error)),
@@ -308,7 +308,7 @@ impl IteratorStage {
 
                         // This should never fail since we're writing to a string.
                         value
-                            .format(context, &mut message, Style::Default, Option::None)
+                            .format(context, &mut message, Style::Default, None)
                             .ok();
 
                         context.log.push_message(crate::LogMessage {
@@ -352,7 +352,7 @@ impl IteratorStage {
                                 if keep.0 {
                                     Some(Ok(value))
                                 } else {
-                                    Option::None
+                                    None
                                 }
                             }
 
@@ -380,7 +380,7 @@ impl IteratorStage {
                                 if mapped != ValueNone.into() {
                                     Some(Ok(mapped))
                                 } else {
-                                    Option::None
+                                    None
                                 }
                             }
 
@@ -451,7 +451,7 @@ impl IteratorStage {
                                 if mapped != ValueNone.into() {
                                     Some(Ok(mapped))
                                 } else {
-                                    Option::None
+                                    None
                                 }
                             }
 
@@ -516,7 +516,7 @@ impl IteratorStage {
                                 if should_continue.0 {
                                     Some(Ok(value))
                                 } else {
-                                    Option::None
+                                    None
                                 }
                             }
                             Err(error) => Some(Err(error)),

--- a/interpreter/src/execution/values/list.rs
+++ b/interpreter/src/execution/values/list.rs
@@ -274,7 +274,7 @@ impl StaticTypeName for List {
 
 impl StaticType for List {
     fn static_type() -> ValueType {
-        ValueType::List(Option::None)
+        ValueType::List(None)
     }
 }
 

--- a/interpreter/src/execution/values/manifold_mesh.rs
+++ b/interpreter/src/execution/values/manifold_mesh.rs
@@ -253,8 +253,8 @@ fn unpack_radius(
     diameter: Option<Length>,
 ) -> ExpressionResult<RawFloat> {
     match (radius, diameter) {
-        (Some(radius), Option::None) => Ok(radius.into()),
-        (Option::None, Some(diameter)) => {
+        (Some(radius), None) => Ok(radius.into()),
+        (None, Some(diameter)) => {
             let diameter: RawFloat = diameter.into();
             Ok(diameter / 2.0)
         }
@@ -262,7 +262,7 @@ fn unpack_radius(
             "You must provide the radius or the diameter, not both".into(),
         )
         .to_error(context.stack_trace)),
-        (Option::None, Option::None) => Err(GenericFailure(
+        (None, None) => Err(GenericFailure(
             "You must provide the radius or the diameter, neither were provided".into(),
         )
         .to_error(context.stack_trace)),

--- a/interpreter/src/execution/values/mod.rs
+++ b/interpreter/src/execution/values/mod.rs
@@ -99,7 +99,7 @@ where
                 let value: Result<ValueNone, Self> = original.into_variant();
 
                 match value {
-                    Ok(_none) => Ok(Option::None),
+                    Ok(_none) => Ok(None),
                     Err(original) => Err(original),
                 }
             }

--- a/interpreter/src/execution/values/scalar.rs
+++ b/interpreter/src/execution/values/scalar.rs
@@ -80,25 +80,25 @@ impl Object for Scalar {
         let unit_name = units::get_base_unit_name(&self.dimension);
 
         match (style, precision, unit_name) {
-            (Style::Default, Option::None, Option::None) => {
+            (Style::Default, None, None) => {
                 write!(f, "{}", self.value)
             }
-            (Style::Default, Option::None, Some(unit_name)) => {
+            (Style::Default, None, Some(unit_name)) => {
                 write!(f, "{}{unit_name}", self.value)
             }
-            (Style::Default, Some(precision), Option::None) => {
+            (Style::Default, Some(precision), None) => {
                 write!(f, "{:.1$}", self.value, precision as usize)
             }
             (Style::Default, Some(precision), Some(unit_name)) => {
                 write!(f, "{:.1$}{unit_name}", self.value, precision as usize)
             }
-            (Style::Debug, Option::None, Option::None) => {
+            (Style::Debug, None, None) => {
                 write!(f, "{}", self.value)
             }
-            (Style::Debug, Option::None, Some(unit_name)) => {
+            (Style::Debug, None, Some(unit_name)) => {
                 write!(f, "{}{unit_name}", self.value)
             }
-            (Style::Debug, Some(precision), Option::None) => {
+            (Style::Debug, Some(precision), None) => {
                 write!(f, "{:.1$}", self.value, precision as usize)
             }
             (Style::Debug, Some(precision), Some(unit_name)) => {
@@ -114,13 +114,13 @@ impl Object for Scalar {
                 // Don't stop execution. Just use default formatting.
                 self.format(context, f, Style::Default, precision)
             }
-            (Style::Exponent, Option::None, Option::None) => {
+            (Style::Exponent, None, None) => {
                 write!(f, "{:e}", self.value.into_inner() as usize)
             }
-            (Style::Exponent, Option::None, Some(unit_name)) => {
+            (Style::Exponent, None, Some(unit_name)) => {
                 write!(f, "{:e}{unit_name}", self.value.into_inner() as usize)
             }
-            (Style::Exponent, Some(precision), Option::None) => {
+            (Style::Exponent, Some(precision), None) => {
                 write!(f, "{:.1$e}", self.value.into_inner(), precision as usize)
             }
             (Style::Exponent, Some(precision), Some(unit_name)) => write!(
@@ -129,13 +129,13 @@ impl Object for Scalar {
                 self.value.into_inner(),
                 precision as usize
             ),
-            (Style::CapitalizedExponent, Option::None, Option::None) => {
+            (Style::CapitalizedExponent, None, None) => {
                 write!(f, "{:E}", self.value.into_inner())
             }
-            (Style::CapitalizedExponent, Option::None, Some(unit_name)) => {
+            (Style::CapitalizedExponent, None, Some(unit_name)) => {
                 write!(f, "{:E}{unit_name}", self.value.into_inner())
             }
-            (Style::CapitalizedExponent, Some(precision), Option::None) => {
+            (Style::CapitalizedExponent, Some(precision), None) => {
                 write!(f, "{:.1$E}", self.value.into_inner(), precision as usize)
             }
             (Style::CapitalizedExponent, Some(precision), Some(unit_name)) => write!(

--- a/interpreter/src/execution/values/string/formatting.rs
+++ b/interpreter/src/execution/values/string/formatting.rs
@@ -456,7 +456,7 @@ mod test {
                     context,
                     &mut formatted,
                     Dictionary::new(
-                        &context,
+                        context,
                         HashMap::from_iter([
                             (
                                 "one".into(),

--- a/interpreter/src/execution/values/string/formatting.rs
+++ b/interpreter/src/execution/values/string/formatting.rs
@@ -191,7 +191,7 @@ impl Format {
             arguments: &Dictionary,
         ) -> ExpressionResult<Option<u8>> {
             match precision {
-                Precision::Default => Ok(Option::None),
+                Precision::Default => Ok(None),
                 Precision::Inline(precision) => Ok(Some(*precision)),
                 Precision::Referenced(name) => {
                     if let Some(argument) = arguments.get(name.as_str()).or_else(|| {

--- a/interpreter/src/execution/values/value_type.rs
+++ b/interpreter/src/execution/values/value_type.rs
@@ -79,7 +79,7 @@ impl ValueType {
             Self::SignedInteger => SignedInteger::static_type_name(),
             Self::UnsignedInteger => UnsignedInteger::static_type_name(),
             Self::Scalar(Some(dimension)) => units::get_dimension_name(dimension),
-            Self::Scalar(Option::None) => "Scalar".into(),
+            Self::Scalar(None) => "Scalar".into(),
             Self::Vector2(Some(dimension)) => {
                 format!("Vector2<{}>", units::get_dimension_name(dimension)).into()
             }
@@ -89,9 +89,9 @@ impl ValueType {
             Self::Vector4(Some(dimension)) => {
                 format!("Vector4<{}>", units::get_dimension_name(dimension)).into()
             }
-            Self::Vector2(Option::None) => "Vector2".into(),
-            Self::Vector3(Option::None) => "Vector3".into(),
-            Self::Vector4(Option::None) => "Vector4".into(),
+            Self::Vector2(None) => "Vector2".into(),
+            Self::Vector3(None) => "Vector3".into(),
+            Self::Vector4(None) => "Vector4".into(),
             Self::String => IString::static_type_name(),
             Self::File => File::static_type_name(),
             Self::Any => "Any".into(),
@@ -128,11 +128,11 @@ impl ValueType {
                     })
                 }
             }
-            (Self::Scalar(Option::None), Self::Scalar(_)) => Ok(()),
-            (Self::Vector2(Option::None), Self::Vector2(_)) => Ok(()),
-            (Self::Vector3(Option::None), Self::Vector3(_)) => Ok(()),
-            (Self::Vector4(Option::None), Self::Vector4(_)) => Ok(()),
-            (Self::List(Option::None), Self::List(_)) => Ok(()),
+            (Self::Scalar(None), Self::Scalar(_)) => Ok(()),
+            (Self::Vector2(None), Self::Vector2(_)) => Ok(()),
+            (Self::Vector3(None), Self::Vector3(_)) => Ok(()),
+            (Self::Vector4(None), Self::Vector4(_)) => Ok(()),
+            (Self::List(None), Self::List(_)) => Ok(()),
             (Self::List(Some(our_type)), Self::List(Some(their_type))) => {
                 our_type.check_other_qualifies(their_type)
             }
@@ -184,7 +184,7 @@ impl Display for ValueType {
             Self::Dictionary(definition) => write!(f, "{}", definition),
             Self::MultiType(left, right) => write!(f, "{left} | {right}"),
             Self::List(Some(ty)) => write!(f, "[{ty}]"),
-            Self::List(Option::None) => write!(f, "[]"),
+            Self::List(None) => write!(f, "[]"),
             Self::ConstraintSet(variables) => {
                 write!(f, "<<<")?;
 

--- a/units/src/lib.rs
+++ b/units/src/lib.rs
@@ -67,7 +67,7 @@ pub fn get_base_unit_name(dimension: &Dimension) -> Option<&'static str> {
 
     match name {
         Some(name) => Some(name),
-        Option::None if *dimension != Dimension::zero() => Some("?"),
-        _ => Option::None,
+        None if *dimension != Dimension::zero() => Some("?"),
+        _ => None,
     }
 }


### PR DESCRIPTION
The standard library was unavailable to rust-analyzer while using the Nix flake.
This problem was caused by https://github.com/nix-community/fenix/issues/232#issuecomment-3918248461

This switches Fenix to the eureka-cpu/rust-analyzer-wrapped branch as a temporary workaround (this will probably break once that branch is merged in and need to be reverted back to the default branch)

It also includes some fixes for clippy warnings that showed up after updating.