### PR TITLE
Better errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -72,9 +72,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.100"
+version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "approx"
@@ -98,7 +98,7 @@ dependencies = [
  "objc2-foundation",
  "parking_lot",
  "percent-encoding",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
  "wl-clipboard-rs",
  "x11rb",
 ]
@@ -127,9 +127,9 @@ checksum = "3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1"
 
 [[package]]
 name = "bitflags"
-version = "2.10.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 dependencies = [
  "serde_core",
 ]
@@ -145,25 +145,26 @@ dependencies = [
 
 [[package]]
 name = "boolmesh"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b5e804fa333a4996316770fff780c7cd006371c58bc7824bd8798f17396eac2"
+version = "0.1.9"
+source = "git+https://github.com/IamTheCarl/boolmesh.git?branch=serde#76b3783817e1e9782e3efd814ca939c869f45a7f"
 dependencies = [
  "glam 0.30.10",
  "rayon",
+ "serde",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "bumpalo"
-version = "3.19.1"
+version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
 name = "bytemuck"
-version = "1.24.0"
+version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fbdf580320f38b612e485521afda1ee26d10cc9884efaaa750d383e13e3c5f4"
+checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
 
 [[package]]
 name = "byteorder"
@@ -173,9 +174,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "cc"
-version = "1.2.53"
+version = "1.2.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "755d2fce177175ffca841e9a06afdb2c4ab0f593d53b4dee48147dfaade85932"
+checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -212,9 +213,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.54"
+version = "4.5.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6e6ff9dcd79cff5cd969a17a545d79e84ab086e444102a591e288a8aa3ce394"
+checksum = "2797f34da339ce31042b27d23607e051786132987f595b02ba4f6a6dffb7030a"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -222,9 +223,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.54"
+version = "4.5.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa42cf4d2b7a41bc8f663a7cab4031ebafa1bf3875705bfaf8466dc60ab52c00"
+checksum = "24a241312cea5059b13574bb9b3861cabf758b879c15190b37b6d6fd63ab6876"
 dependencies = [
  "anstream",
  "anstyle",
@@ -234,9 +235,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.49"
+version = "4.5.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a0b5487afeab2deb2ff4e03a807ad1a03ac532ff5a2cee5d86884440c7f7671"
+checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -246,9 +247,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.7"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3e64b0cc0439b12df2fa678eae89a1c56a529fd067a9115f7827f1fffd22b32"
+checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
 
 [[package]]
 name = "cli"
@@ -341,9 +342,9 @@ dependencies = [
 
 [[package]]
 name = "crokey"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51360853ebbeb3df20c76c82aecf43d387a62860f1a59ba65ab51f00eea85aad"
+checksum = "04a63daf06a168535c74ab97cdba3ed4fa5d4f32cb36e437dcceb83d66854b7c"
 dependencies = [
  "crokey-proc_macros",
  "crossterm",
@@ -354,9 +355,9 @@ dependencies = [
 
 [[package]]
 name = "crokey-proc_macros"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bf1a727caeb5ee5e0a0826a97f205a9cf84ee964b0b48239fef5214a00ae439"
+checksum = "847f11a14855fc490bd5d059821895c53e77eeb3c2b73ee3dded7ce77c93b231"
 dependencies = [
  "crossterm",
  "proc-macro2",
@@ -669,9 +670,9 @@ dependencies = [
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8591b0bcc8a98a64310a2fae1bb3e9b8564dd10e381e6e28010fde8e8e8568db"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "fixedbitset"
@@ -739,6 +740,19 @@ dependencies = [
  "libc",
  "r-efi",
  "wasip2",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139ef39800118c7683f2fd3c98c1b23c09ae076556b435f8e9064ae108aaeeec"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+ "wasip3",
 ]
 
 [[package]]
@@ -851,6 +865,9 @@ name = "glam"
 version = "0.30.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19fc433e8437a212d1b6f1e68c7824af3aed907da60afa994e7f542d18d12aa9"
+dependencies = [
+ "serde_core",
+]
 
 [[package]]
 name = "hashable-map"
@@ -890,9 +907,9 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.64"
+version = "0.1.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33e57f83510bb73707521ebaffa789ec8caf86f9657cad665b092b581d40e9fb"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
@@ -994,6 +1011,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1028,6 +1051,8 @@ checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
  "equivalent",
  "hashbrown 0.16.1",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -1110,7 +1135,7 @@ version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
 dependencies = [
- "getrandom",
+ "getrandom 0.3.4",
  "libc",
 ]
 
@@ -1122,9 +1147,9 @@ checksum = "e90f66baf362a8a5ce2ca820290fbede0572a76fabf8408bc68c02f9ad1d03bf"
 
 [[package]]
 name = "js-sys"
-version = "0.3.85"
+version = "0.3.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c942ebf8e95485ca0d52d97da7c5a2c387d0e7f0ba4c35e93bfcaee045955b3"
+checksum = "93f0862381daaec758576dcc22eb7bbf4d7efd67328553f3b45a412a51a3fb21"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -1132,9 +1157,9 @@ dependencies = [
 
 [[package]]
 name = "lazy-regex"
-version = "3.5.1"
+version = "3.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5c13b6857ade4c8ee05c3c3dc97d2ab5415d691213825b90d3211c425c1f907"
+checksum = "6bae91019476d3ec7147de9aa291cadb6d870abf2f3015d2da73a90325ac1496"
 dependencies = [
  "lazy-regex-proc_macros",
  "once_cell",
@@ -1143,9 +1168,9 @@ dependencies = [
 
 [[package]]
 name = "lazy-regex-proc_macros"
-version = "3.5.1"
+version = "3.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a95c68db5d41694cea563c86a4ba4dc02141c16ef64814108cb23def4d5438"
+checksum = "4de9c1e1439d8b7b3061b2d209809f447ca33241733d9a3c01eabf2dc8d94358"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1160,6 +1185,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
 name = "levenshtein"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1167,9 +1198,9 @@ checksum = "db13adb97ab515a3691f56e4dbab09283d0b86cb45abd991d8634a9d6f501760"
 
 [[package]]
 name = "libc"
-version = "0.2.180"
+version = "0.2.182"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
+checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
 
 [[package]]
 name = "libgit2-sys"
@@ -1300,9 +1331,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.6"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "minimad"
@@ -1681,9 +1712,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.105"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "535d180e0ecab6268a3e718bb9fd44db66bbbc256257165fc699dadf70d16fe7"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
@@ -1721,9 +1752,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.43"
+version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc74d9a594b72ae6656596548f56f667211f8a97b3d4c3d467150794690dc40a"
+checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
 dependencies = [
  "proc-macro2",
 ]
@@ -1800,7 +1831,7 @@ dependencies = [
  "strip-ansi-escapes",
  "strum",
  "strum_macros",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "unicase",
  "unicode-segmentation",
  "unicode-width 0.2.2",
@@ -1808,9 +1839,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.2"
+version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1820,9 +1851,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1831,9 +1862,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
+checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
 
 [[package]]
 name = "rustc-stable-hash"
@@ -1871,9 +1902,9 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ryu"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a50f4cf475b65d88e057964e0e9bb1f0aa9bbb2036dc65c64596b42932536984"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "safe_arch"
@@ -2018,9 +2049,9 @@ dependencies = [
 
 [[package]]
 name = "siphasher"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
+checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
 name = "slice-group-by"
@@ -2107,9 +2138,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.114"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4d107df263a3013ef9b1879b0df87d706ff80f65a86ea879bd9c31f9b307c2a"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2129,12 +2160,12 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.24.0"
+version = "3.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "655da9c7eb6305c55742045d5a8d2037996d61d8de95806335c7c86ce0f82e9c"
+checksum = "0136791f7c95b1f6dd99f9cc786b91bb81c3800b639b3478e561ddb7be95e5f1"
 dependencies = [
  "fastrand",
- "getrandom",
+ "getrandom 0.4.1",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -2152,7 +2183,7 @@ dependencies = [
  "lazy-regex",
  "minimad",
  "serde",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "unicode-width 0.1.14",
 ]
 
@@ -2167,11 +2198,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.17"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl 2.0.17",
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -2187,9 +2218,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.17"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2230,9 +2261,9 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter-language"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ae62f7eae5eb549c71b76658648b72cc6111f2d87d24a1e31fa907f4943e3ce"
+checksum = "009994f150cc0cd50ff54917d5bc8bffe8cad10ca10d81c34da2ec421ae61782"
 
 [[package]]
 name = "tree_magic_mini"
@@ -2327,9 +2358,9 @@ checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.22"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-segmentation"
@@ -2348,6 +2379,12 @@ name = "unicode-width"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "units"
@@ -2451,10 +2488,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-bindgen"
-version = "0.2.108"
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64024a30ec1e37399cf85a7ffefebdb72205ca1c972291c51512360d90bd8566"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.110"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1de241cdc66a9d91bd84f097039eb140cdc6eec47e0cdbaf9d932a1dd6c35866"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -2465,9 +2511,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.108"
+version = "0.2.110"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "008b239d9c740232e71bd39e8ef6429d27097518b6b30bdf9086833bd5b6d608"
+checksum = "e12fdf6649048f2e3de6d7d5ff3ced779cdedee0e0baffd7dff5cdfa3abc8a52"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2475,9 +2521,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.108"
+version = "0.2.110"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5256bae2d58f54820e6490f9839c49780dff84c65aeab9e772f15d5f0e913a55"
+checksum = "0e63d1795c565ac3462334c1e396fd46dbf481c40f51f5072c310717bc4fb309"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -2488,11 +2534,45 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.108"
+version = "0.2.110"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
+checksum = "e9f9cdac23a5ce71f6bf9f8824898a501e511892791ea2a0c6b8568c68b9cb53"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
 ]
 
 [[package]]
@@ -2671,7 +2751,16 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
 ]
 
 [[package]]
@@ -2689,14 +2778,31 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -2706,10 +2812,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2718,10 +2836,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -2730,10 +2860,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -2742,16 +2884,110 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
 name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
 
 [[package]]
 name = "wl-clipboard-rs"
@@ -2763,7 +2999,7 @@ dependencies = [
  "log",
  "os_pipe",
  "rustix",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tree_magic_mini",
  "wayland-backend",
  "wayland-client",
@@ -2879,6 +3115,6 @@ dependencies = [
 
 [[package]]
 name = "zmij"
-version = "1.0.14"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd8f3f50b848df28f887acb68e41201b5aea6bc8a8dacc00fb40635ff9a72fea"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1082,6 +1082,7 @@ dependencies = [
  "stack",
  "stl_io",
  "tempfile",
+ "thiserror 2.0.18",
  "tree-sitter",
  "tree-sitter-command-cad-model",
  "type-sitter",

--- a/interpreter/Cargo.toml
+++ b/interpreter/Cargo.toml
@@ -28,7 +28,8 @@ selen = "0.15.5"
 sha2 = "0.10.9"
 serde = { version = "1.0.228", features = ["derive"] }
 hex = "0.4.3"
-boolmesh = { version = "0.1.7", features = ["rayon"] }
+# boolmesh = { version = "0.1.7", features = ["rayon"] }
+boolmesh = { git = "https://github.com/IamTheCarl/boolmesh.git", branch = "serde", features = ["rayon", "serde"] }
 stl_io = "0.10.0"
 itertools = "0.14.0"
 

--- a/interpreter/Cargo.toml
+++ b/interpreter/Cargo.toml
@@ -32,6 +32,7 @@ hex = "0.4.3"
 boolmesh = { git = "https://github.com/IamTheCarl/boolmesh.git", branch = "serde", features = ["rayon", "serde"] }
 stl_io = "0.10.0"
 itertools = "0.14.0"
+thiserror = "2.0.18"
 
 [build-dependencies]
 type-sitter-gen = "0.8"

--- a/interpreter/src/execution/errors.rs
+++ b/interpreter/src/execution/errors.rs
@@ -22,7 +22,7 @@ use ariadne::{Label, Report, ReportKind};
 
 use crate::compile::SourceReference;
 
-pub type ExpressionResult<R> = std::result::Result<R, Error>;
+pub type ExecutionResult<R> = std::result::Result<R, Error>;
 
 #[derive(Debug)]
 pub struct Error {

--- a/interpreter/src/execution/errors.rs
+++ b/interpreter/src/execution/errors.rs
@@ -60,7 +60,7 @@ impl std::error::Error for Error {}
 #[derive(Debug, Eq, PartialEq)]
 pub struct GenericFailure(pub Cow<'static, str>);
 
-impl ErrorType for GenericFailure {}
+impl std::error::Error for GenericFailure {}
 
 impl Display for GenericFailure {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -68,7 +68,9 @@ impl Display for GenericFailure {
     }
 }
 
-pub trait ErrorType: std::fmt::Debug + std::fmt::Display + Any + Send + Sync {}
+pub trait ErrorType: std::error::Error + Send + Sync + Any {}
+
+impl<E> ErrorType for E where E: std::error::Error + Send + Sync + 'static {}
 
 pub trait Raise {
     fn to_error<'s>(self, stack_trace: impl IntoIterator<Item = &'s SourceReference>) -> Error;

--- a/interpreter/src/execution/errors.rs
+++ b/interpreter/src/execution/errors.rs
@@ -16,7 +16,7 @@
  * program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-use std::{any::Any, borrow::Cow, fmt::Display};
+use std::{any::Any, fmt::Display};
 
 use ariadne::{Label, Report, ReportKind};
 
@@ -58,11 +58,23 @@ impl std::error::Error for Error {}
 
 /// A generic error that will just display a static message.
 #[derive(Debug, Eq, PartialEq)]
-pub struct GenericFailure(pub Cow<'static, str>);
+pub struct StrError(pub &'static str);
 
-impl std::error::Error for GenericFailure {}
+impl std::error::Error for StrError {}
 
-impl Display for GenericFailure {
+impl Display for StrError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+/// A generic error that will just display a formatted message.
+#[derive(Debug, Eq, PartialEq)]
+pub struct StringError(pub String);
+
+impl std::error::Error for StringError {}
+
+impl Display for StringError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.0)
     }

--- a/interpreter/src/execution/errors.rs
+++ b/interpreter/src/execution/errors.rs
@@ -86,9 +86,18 @@ impl Display for StringError {
     }
 }
 
-pub trait ErrorType: std::error::Error + Send + Sync + Any {}
+pub trait ErrorType: std::error::Error + Send + Sync + Any {
+    fn as_any(&self) -> &dyn Any;
+}
 
-impl<E> ErrorType for E where E: std::error::Error + Send + Sync + 'static {}
+impl<E> ErrorType for E
+where
+    E: std::error::Error + Send + Sync + Any,
+{
+    fn as_any(&self) -> &dyn Any {
+        self as &dyn Any
+    }
+}
 
 pub trait Raise {
     fn to_error<'s>(self, stack_trace: impl IntoIterator<Item = &'s SourceReference>) -> Error;

--- a/interpreter/src/execution/errors.rs
+++ b/interpreter/src/execution/errors.rs
@@ -30,6 +30,12 @@ pub struct Error {
     pub trace: Vec<SourceReference>,
 }
 
+// Error: Doing thing with context
+//
+// Caused by:
+//     0: Doing thing with extra context
+//     1: Failed
+
 impl Error {
     pub fn report(&self) -> Report<'_, SourceReference> {
         let bottom = self.trace.first().expect("Error has no trace").clone();

--- a/interpreter/src/execution/errors.rs
+++ b/interpreter/src/execution/errors.rs
@@ -16,11 +16,11 @@
  * program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-use std::{any::Any, fmt::Display};
+use std::{any::Any, borrow::Cow, fmt::Display};
 
 use ariadne::{Label, Report, ReportKind};
 
-use crate::compile::SourceReference;
+use crate::{compile::SourceReference, StackTrace};
 
 pub type ExecutionResult<R> = std::result::Result<R, Error>;
 
@@ -28,13 +28,8 @@ pub type ExecutionResult<R> = std::result::Result<R, Error>;
 pub struct Error {
     pub ty: Box<dyn ErrorType>,
     pub trace: Vec<SourceReference>,
+    pub failure_chain: Vec<Cow<'static, str>>,
 }
-
-// Error: Doing thing with context
-//
-// Caused by:
-//     0: Doing thing with extra context
-//     1: Failed
 
 impl Error {
     pub fn report(&self) -> Report<'_, SourceReference> {
@@ -43,6 +38,8 @@ impl Error {
         let mut builder = Report::build(ReportKind::Error, bottom.clone());
         builder.set_message("Failed to evaluate");
         builder.add_label(Label::new(bottom).with_message(format!("{}", self.ty)));
+
+        builder.with_helps(self.failure_chain.iter());
 
         builder.finish()
     }
@@ -100,14 +97,25 @@ where
 }
 
 pub trait Raise {
-    fn to_error<'s>(self, stack_trace: impl IntoIterator<Item = &'s SourceReference>) -> Error;
+    fn to_error<'s>(self, stack_trace: impl IntoIterator<Item = &'s StackTrace<'s>>) -> Error;
 }
 
 impl<E: ErrorType> Raise for E {
-    fn to_error<'s>(self, stack_trace: impl IntoIterator<Item = &'s SourceReference>) -> Error {
+    fn to_error<'s>(self, stack_trace: impl IntoIterator<Item = &'s StackTrace<'s>>) -> Error {
+        let mut trace = Vec::new();
+        let mut failure_chain = Vec::new();
+
+        for layer in stack_trace {
+            trace.push(layer.reference.clone());
+            if let Some(message) = layer.failure_message.clone() {
+                failure_chain.push(message);
+            }
+        }
+
         Error {
             ty: Box::new(self),
-            trace: stack_trace.into_iter().cloned().collect(),
+            trace,
+            failure_chain,
         }
     }
 }

--- a/interpreter/src/execution/logging.rs
+++ b/interpreter/src/execution/logging.rs
@@ -124,15 +124,22 @@ impl<'p> StackTrace<'p> {
         code: F,
     ) -> R
     where
-        F: FnOnce(StackTrace<'p>) -> R,
+        F: FnOnce(&StackTrace<'p>) -> R,
     {
-        let scope = Self {
-            parent: Some(self),
-            reference: reference.into(),
-            failure_message,
-        };
+        let reference = reference.into();
 
-        code(scope)
+        if self.reference != reference || self.failure_message != failure_message {
+            let scope = Self {
+                parent: Some(self),
+                reference,
+                failure_message,
+            };
+
+            code(&scope)
+        } else {
+            // This is not actually a new scope
+            code(self)
+        }
     }
 
     pub fn bottom(&self) -> &SourceReference {

--- a/interpreter/src/execution/logging.rs
+++ b/interpreter/src/execution/logging.rs
@@ -59,6 +59,7 @@ impl RuntimeLog for Mutex<Vec<LogMessage>> {
 pub struct StackTrace<'p> {
     parent: Option<&'p StackTrace<'p>>,
     reference: SourceReference,
+    failure_message: Option<Cow<'static, str>>,
 }
 
 impl<'p> Display for StackTrace<'p> {
@@ -76,6 +77,7 @@ impl StackTrace<'static> {
         Self {
             parent: None,
             reference,
+            failure_message: None,
         }
     }
 
@@ -92,6 +94,7 @@ impl StackTrace<'static> {
                     end_point: Point { row: 0, column: 0 },
                 },
             },
+            failure_message: Some("Bootstrap failed".into()),
         }
     }
 
@@ -108,18 +111,25 @@ impl StackTrace<'static> {
                     end_point: Point { row: 0, column: 0 },
                 },
             },
+            failure_message: Some("Test failed".into()),
         }
     }
 }
 
 impl<'p> StackTrace<'p> {
-    pub fn trace_scope<F, R>(&'p self, reference: impl Into<SourceReference>, code: F) -> R
+    pub fn trace_scope<F, R>(
+        &'p self,
+        failure_message: Option<Cow<'static, str>>,
+        reference: impl Into<SourceReference>,
+        code: F,
+    ) -> R
     where
         F: FnOnce(StackTrace<'p>) -> R,
     {
         let scope = Self {
             parent: Some(self),
             reference: reference.into(),
+            failure_message,
         };
 
         code(scope)

--- a/interpreter/src/execution/logging.rs
+++ b/interpreter/src/execution/logging.rs
@@ -57,9 +57,9 @@ impl RuntimeLog for Mutex<Vec<LogMessage>> {
 
 #[derive(Debug, Clone)]
 pub struct StackTrace<'p> {
-    parent: Option<&'p StackTrace<'p>>,
-    reference: SourceReference,
-    failure_message: Option<Cow<'static, str>>,
+    pub parent: Option<&'p StackTrace<'p>>,
+    pub reference: SourceReference,
+    pub failure_message: Option<Cow<'static, str>>,
 }
 
 impl<'p> Display for StackTrace<'p> {
@@ -154,7 +154,7 @@ impl<'p> StackTrace<'p> {
 }
 
 impl<'p> IntoIterator for &'p StackTrace<'p> {
-    type Item = &'p SourceReference;
+    type Item = &'p StackTrace<'p>;
     type IntoIter = StackTraceIter<'p>;
 
     fn into_iter(self) -> Self::IntoIter {
@@ -167,14 +167,14 @@ pub struct StackTraceIter<'p> {
 }
 
 impl<'p> Iterator for StackTraceIter<'p> {
-    type Item = &'p SourceReference;
+    type Item = &'p StackTrace<'p>;
 
     fn next(&mut self) -> Option<Self::Item> {
         let next = self.current.take();
         if let Some(next) = next {
             self.current = next.parent;
         }
-        next.map(|next| &next.reference)
+        next
     }
 }
 

--- a/interpreter/src/execution/mod.rs
+++ b/interpreter/src/execution/mod.rs
@@ -524,7 +524,7 @@ pub fn execute_if_expression(
     expression: &compile::AstNode<Box<compile::IfExpression>>,
 ) -> ExecutionResult<Value> {
     let condition = execute_expression(context, &expression.node.condition)?
-        .downcast::<values::Boolean>(context.stack_trace)?
+        .downcast::<values::Boolean>(context)?
         .0;
 
     let expression = if condition {

--- a/interpreter/src/execution/mod.rs
+++ b/interpreter/src/execution/mod.rs
@@ -277,7 +277,7 @@ impl<'c> ExecutionContext<'c> {
 }
 
 impl<'s> IntoIterator for &'s ExecutionContext<'_> {
-    type Item = &'s SourceReference;
+    type Item = &'s StackTrace<'s>;
 
     type IntoIter = StackTraceIter<'s>;
 

--- a/interpreter/src/execution/mod.rs
+++ b/interpreter/src/execution/mod.rs
@@ -232,7 +232,7 @@ impl<'c> ExecutionContext<'c> {
         self.stack_trace
             .trace_scope(failure_message, reference, move |stack_trace| {
                 let context = ExecutionContext {
-                    stack_trace: &stack_trace,
+                    stack_trace,
                     ..*self
                 };
 
@@ -595,66 +595,69 @@ pub fn run_file(context: &ExecutionContext, file: impl Into<PathBuf>) -> Executi
     // TODO can/should we make the parser part of the execution context rather than build a new one
     // every time we load a file?
     let mut parser = new_parser();
-
     let file = file.into();
 
-    if file.is_absolute() {
-        return Err(
-            StrError("Absolute paths cannot be used for importing files").to_error(context),
-        );
-    }
-
-    if context.import_limit == 0 {
-        return Err(StrError("Import recursion depth has been exceeded").to_error(context));
-    }
-
-    let file = context.working_directory.join(file);
-    let parent_dir = file
-        .parent()
-        .ok_or_else(|| StrError("Failed to get parent directory of file").to_error(context))?;
-
-    let root = {
-        let mut files = context
-            .file_cache
-            .lock()
-            .map_err(|_error| StrError("Failed to lock file cache").to_error(context))?;
-        let file = Arc::new(file.clone());
-        let input = match files.entry(file.clone()) {
-            std::collections::hash_map::Entry::Occupied(entry) => entry,
-            std::collections::hash_map::Entry::Vacant(vacency) => {
-                let input = std::fs::read_to_string(file.as_path()).map_err(|error| {
-                    StringError(format!("Failed to read file {:?} from disk: {error}", file))
-                        .to_error(context)
-                })?;
-                let input = ImString::from(input);
-
-                vacency.insert_entry(Source::from(input))
+    context.trace_scope(
+        Some("Failed to import {file:?}".into()),
+        context.stack_trace.bottom().clone(),
+        |context| {
+            if file.is_absolute() {
+                return Err(
+                    StrError("Absolute paths cannot be used for importing files").to_error(context),
+                );
             }
-        };
-        let input = input.get().text();
 
-        let tree = parser.parse(input, None).map_err(|error| {
-            StringError(format!("Failed to parse input: {error:?}")).to_error(context)
-        })?;
+            if context.import_limit == 0 {
+                return Err(StrError("Import recursion depth has been exceeded").to_error(context));
+            }
 
-        let root = crate::compile(&file, input, &tree).map_err(|error| {
-            StringError(format!("Failed to compile: {error}")).to_error(context)
-        })?;
+            let file = context.working_directory.join(file);
+            let parent_dir = file.parent().ok_or_else(|| {
+                StrError("Failed to get parent directory of file").to_error(context)
+            })?;
 
-        context
-            .log
-            .collect_syntax_errors(input, &tree, &file, root.reference.clone());
+            let root = {
+                let mut files = context
+                    .file_cache
+                    .lock()
+                    .map_err(|_error| StrError("Failed to lock file cache").to_error(context))?;
+                let file = Arc::new(file.clone());
+                let input = match files.entry(file.clone()) {
+                    std::collections::hash_map::Entry::Occupied(entry) => entry,
+                    std::collections::hash_map::Entry::Vacant(vacency) => {
+                        let input = std::fs::read_to_string(file.as_path())
+                            .map_err(|error| error.to_error(context))?;
+                        let input = ImString::from(input);
 
-        root
-    };
+                        vacency.insert_entry(Source::from(input))
+                    }
+                };
+                let input = input.get().text();
 
-    let context = ExecutionContext {
-        working_directory: parent_dir,
-        import_limit: context.import_limit - 1,
-        ..context.clone()
-    };
+                let tree = parser.parse(input, None).map_err(|error| {
+                    StringError(format!("Failed to parse input: {error:?}")).to_error(context)
+                })?;
 
-    execute_expression(&context, &root)
+                let root = crate::compile(&file, input, &tree).map_err(|error| {
+                    StringError(format!("Failed to compile: {error}")).to_error(context)
+                })?;
+
+                context
+                    .log
+                    .collect_syntax_errors(input, &tree, &file, root.reference.clone());
+
+                root
+            };
+
+            let context = ExecutionContext {
+                working_directory: parent_dir,
+                import_limit: context.import_limit - 1,
+                ..context.clone()
+            };
+
+            execute_expression(&context, &root)
+        },
+    )
 }
 
 pub mod functions {

--- a/interpreter/src/execution/mod.rs
+++ b/interpreter/src/execution/mod.rs
@@ -17,6 +17,7 @@
  */
 
 use std::{
+    borrow::Cow,
     cmp::Ordering,
     collections::HashMap,
     path::{Path, PathBuf},
@@ -219,18 +220,24 @@ pub struct ExecutionContext<'c> {
 }
 
 impl<'c> ExecutionContext<'c> {
-    pub fn trace_scope<F, R>(&'c self, reference: impl Into<SourceReference>, code: F) -> R
+    pub fn trace_scope<F, R>(
+        &'c self,
+        failure_message: Option<Cow<'static, str>>,
+        reference: impl Into<SourceReference>,
+        code: F,
+    ) -> R
     where
         F: FnOnce(&ExecutionContext<'_>) -> R,
     {
-        self.stack_trace.trace_scope(reference, move |stack_trace| {
-            let context = ExecutionContext {
-                stack_trace: &stack_trace,
-                ..*self
-            };
+        self.stack_trace
+            .trace_scope(failure_message, reference, move |stack_trace| {
+                let context = ExecutionContext {
+                    stack_trace: &stack_trace,
+                    ..*self
+                };
 
-            code(&context)
-        })
+                code(&context)
+            })
     }
 
     pub fn get_variable<'s, S: Into<LocatedStr<'s>>>(&self, name: S) -> ExecutionResult<&Value> {
@@ -282,8 +289,10 @@ pub fn execute_expression(
     context: &ExecutionContext,
     expression: &compile::AstNode<compile::Expression>,
 ) -> ExecutionResult<Value> {
-    context.trace_scope(expression.reference.clone(), |context| {
-        match &expression.node {
+    context.trace_scope(
+        None,
+        expression.reference.clone(),
+        |context| match &expression.node {
             compile::Expression::BinaryExpression(ast_node) => {
                 execute_binary_expression(context, ast_node)
             }
@@ -302,7 +311,7 @@ pub fn execute_expression(
             compile::Expression::MemberAccess(ast_node) => {
                 let base = execute_expression(context, &ast_node.node.base)?;
 
-                context.trace_scope(ast_node.node.member.reference.clone(), |context| {
+                context.trace_scope(None, ast_node.node.member.reference.clone(), |context| {
                     base.get_attribute(context, &ast_node.node.member.node)
                 })
             }
@@ -356,15 +365,15 @@ pub fn execute_expression(
             compile::Expression::Malformed(kind) => {
                 Err(StringError(format!("Malformed syntax, expected {kind}")).to_error(context))
             }
-        }
-    })
+        },
+    )
 }
 
 fn execute_unary_expression(
     context: &ExecutionContext,
     expression: &compile::AstNode<Box<compile::UnaryExpression>>,
 ) -> ExecutionResult<Value> {
-    context.trace_scope(expression.reference.clone(), |context| {
+    context.trace_scope(None, expression.reference.clone(), |context| {
         let node = &expression.node;
         let value = execute_expression(context, &node.expression)?;
         match node.operation.node {
@@ -410,7 +419,7 @@ fn execute_let_in(
     context: &ExecutionContext,
     expression: &compile::AstNode<Box<compile::LetIn>>,
 ) -> ExecutionResult<Value> {
-    context.trace_scope(expression.reference.clone(), |context| {
+    context.trace_scope(None, expression.reference.clone(), |context| {
         context.stack.scope_mut(
             context.stack_trace,
             ScopeType::Inherited,
@@ -454,7 +463,7 @@ fn execute_binary_expression(
     context: &ExecutionContext,
     expression: &compile::AstNode<Box<compile::BinaryExpression>>,
 ) -> ExecutionResult<Value> {
-    context.trace_scope(expression.reference.clone(), |context| {
+    context.trace_scope(None, expression.reference.clone(), |context| {
         let node = &expression.node;
 
         let (result_a, result_b) = join(

--- a/interpreter/src/execution/mod.rs
+++ b/interpreter/src/execution/mod.rs
@@ -463,69 +463,63 @@ fn execute_binary_expression(
     context: &ExecutionContext,
     expression: &compile::AstNode<Box<compile::BinaryExpression>>,
 ) -> ExecutionResult<Value> {
-    context.trace_scope(None, expression.reference.clone(), |context| {
-        let node = &expression.node;
+    let node = &expression.node;
 
-        let (result_a, result_b) = join(
-            || execute_expression(context, &node.a),
-            || execute_expression(context, &node.b),
-        );
+    let (result_a, result_b) = join(
+        || execute_expression(context, &node.a),
+        || execute_expression(context, &node.b),
+    );
 
-        let value_a = result_a?;
-        let value_b = result_b?;
+    let value_a = result_a?;
+    let value_b = result_b?;
 
-        match node.operation.node {
-            BinaryExpressionOperation::NotEq => Ok(values::Boolean(
-                !value_a
-                    .clone()
-                    .cmp(context, value_b.clone())
-                    .map(|ord| matches!(ord, Ordering::Equal))
-                    .or_else(|_| value_a.eq(context, value_b))?,
-            )
-            .into()),
-            BinaryExpressionOperation::And => value_a.bit_and(context, value_b),
-            BinaryExpressionOperation::AndAnd => value_a.and(context, value_b),
-            BinaryExpressionOperation::Mul => value_a.multiply(context, value_b),
-            BinaryExpressionOperation::MulMul => value_a.exponent(context, value_b),
-            BinaryExpressionOperation::Add => value_a.addition(context, value_b),
-            BinaryExpressionOperation::Sub => value_a.subtraction(context, value_b),
-            BinaryExpressionOperation::Div => value_a.divide(context, value_b),
-            BinaryExpressionOperation::Lt => Ok(values::Boolean(matches!(
-                value_a.cmp(context, value_b)?,
-                Ordering::Less
-            ))
-            .into()),
-            BinaryExpressionOperation::LtLt => value_a.left_shift(context, value_b),
-            BinaryExpressionOperation::LtEq => Ok(values::Boolean(matches!(
-                value_a.cmp(context, value_b)?,
-                Ordering::Less | Ordering::Equal
-            ))
-            .into()),
-            BinaryExpressionOperation::EqEq => Ok(values::Boolean(
-                value_a
-                    .clone()
-                    .cmp(context, value_b.clone())
-                    .map(|ord| matches!(ord, Ordering::Equal))
-                    .or_else(|_| value_a.eq(context, value_b))?,
-            )
-            .into()),
-            BinaryExpressionOperation::Gt => Ok(values::Boolean(matches!(
-                value_a.cmp(context, value_b)?,
-                Ordering::Greater
-            ))
-            .into()),
-            BinaryExpressionOperation::GtEq => Ok(values::Boolean(matches!(
-                value_a.cmp(context, value_b)?,
-                Ordering::Equal | Ordering::Greater
-            ))
-            .into()),
-            BinaryExpressionOperation::GtGt => value_a.right_shift(context, value_b),
-            BinaryExpressionOperation::BitXor => value_a.bit_xor(context, value_b),
-            BinaryExpressionOperation::Xor => value_a.xor(context, value_b),
-            BinaryExpressionOperation::Or => value_a.bit_or(context, value_b),
-            BinaryExpressionOperation::OrOr => value_a.or(context, value_b),
+    match node.operation.node {
+        BinaryExpressionOperation::NotEq => Ok(values::Boolean(
+            !value_a
+                .clone()
+                .cmp(context, value_b.clone())
+                .map(|ord| matches!(ord, Ordering::Equal))
+                .or_else(|_| value_a.eq(context, value_b))?,
+        )
+        .into()),
+        BinaryExpressionOperation::And => value_a.bit_and(context, value_b),
+        BinaryExpressionOperation::AndAnd => value_a.and(context, value_b),
+        BinaryExpressionOperation::Mul => value_a.multiply(context, value_b),
+        BinaryExpressionOperation::MulMul => value_a.exponent(context, value_b),
+        BinaryExpressionOperation::Add => value_a.addition(context, value_b),
+        BinaryExpressionOperation::Sub => value_a.subtraction(context, value_b),
+        BinaryExpressionOperation::Div => value_a.divide(context, value_b),
+        BinaryExpressionOperation::Lt => {
+            Ok(values::Boolean(matches!(value_a.cmp(context, value_b)?, Ordering::Less)).into())
         }
-    })
+        BinaryExpressionOperation::LtLt => value_a.left_shift(context, value_b),
+        BinaryExpressionOperation::LtEq => Ok(values::Boolean(matches!(
+            value_a.cmp(context, value_b)?,
+            Ordering::Less | Ordering::Equal
+        ))
+        .into()),
+        BinaryExpressionOperation::EqEq => Ok(values::Boolean(
+            value_a
+                .clone()
+                .cmp(context, value_b.clone())
+                .map(|ord| matches!(ord, Ordering::Equal))
+                .or_else(|_| value_a.eq(context, value_b))?,
+        )
+        .into()),
+        BinaryExpressionOperation::Gt => {
+            Ok(values::Boolean(matches!(value_a.cmp(context, value_b)?, Ordering::Greater)).into())
+        }
+        BinaryExpressionOperation::GtEq => Ok(values::Boolean(matches!(
+            value_a.cmp(context, value_b)?,
+            Ordering::Equal | Ordering::Greater
+        ))
+        .into()),
+        BinaryExpressionOperation::GtGt => value_a.right_shift(context, value_b),
+        BinaryExpressionOperation::BitXor => value_a.bit_xor(context, value_b),
+        BinaryExpressionOperation::Xor => value_a.xor(context, value_b),
+        BinaryExpressionOperation::Or => value_a.bit_or(context, value_b),
+        BinaryExpressionOperation::OrOr => value_a.or(context, value_b),
+    }
 }
 
 pub fn execute_if_expression(

--- a/interpreter/src/execution/mod.rs
+++ b/interpreter/src/execution/mod.rs
@@ -57,6 +57,7 @@ pub use stack::StackScope;
 mod store;
 pub use store::Store;
 
+use thiserror::Error;
 use values::{
     closure::find_all_variable_accesses_in_closure_capture,
     dictionary::find_all_variable_accesses_in_dictionary_construction, Object, Value, ValueType,
@@ -591,6 +592,18 @@ pub(crate) fn test_context_custom_database<R>(
     f(&context)
 }
 
+#[derive(Debug, Error, Eq, PartialEq)]
+pub enum FileRunError {
+    #[error("Absolute paths cannot be used for importing files")]
+    AbsolutePath,
+
+    #[error("Import recursion depth has been exceeded")]
+    ImportDepth,
+
+    #[error("Failed to get parent directory of file")]
+    NoParentDirectory,
+}
+
 pub fn run_file(context: &ExecutionContext, file: impl Into<PathBuf>) -> ExecutionResult<Value> {
     // TODO can/should we make the parser part of the execution context rather than build a new one
     // every time we load a file?
@@ -598,23 +611,21 @@ pub fn run_file(context: &ExecutionContext, file: impl Into<PathBuf>) -> Executi
     let file = file.into();
 
     context.trace_scope(
-        Some("Failed to import {file:?}".into()),
+        Some(format!("Failed to import {file:?}").into()),
         context.stack_trace.bottom().clone(),
         |context| {
             if file.is_absolute() {
-                return Err(
-                    StrError("Absolute paths cannot be used for importing files").to_error(context),
-                );
+                return Err(FileRunError::AbsolutePath.to_error(context));
             }
 
             if context.import_limit == 0 {
-                return Err(StrError("Import recursion depth has been exceeded").to_error(context));
+                return Err(FileRunError::ImportDepth.to_error(context));
             }
 
             let file = context.working_directory.join(file);
-            let parent_dir = file.parent().ok_or_else(|| {
-                StrError("Failed to get parent directory of file").to_error(context)
-            })?;
+            let parent_dir = file
+                .parent()
+                .ok_or_else(|| FileRunError::NoParentDirectory.to_error(context))?;
 
             let root = {
                 let mut files = context
@@ -787,6 +798,10 @@ mod test {
 
     #[test]
     fn infinite_recursion_import() {
-        test_run("std.import(path = \"./test_assets/infinite_recursion_import.ccm\")").unwrap_err();
+        let error = test_run("std.import(path = \"./test_assets/infinite_recursion_import.ccm\")")
+            .unwrap_err();
+        let error = error.ty.as_any();
+        let error: &FileRunError = error.downcast_ref().unwrap();
+        assert_eq!(*error, FileRunError::ImportDepth);
     }
 }

--- a/interpreter/src/execution/stack.rs
+++ b/interpreter/src/execution/stack.rs
@@ -19,7 +19,7 @@
 use crate::execution::logging::StackTrace;
 
 use super::{
-    errors::{ErrorType, ExpressionResult, Raise},
+    errors::{ErrorType, ExecutionResult, Raise},
     logging::LocatedStr,
     values::Value,
 };
@@ -57,7 +57,7 @@ impl<'p> StackScope<'p> {
         mode: ScopeType,
         variables: HashMap<ImString, Value>,
         block: B,
-    ) -> ExpressionResult<R>
+    ) -> ExecutionResult<R>
     where
         B: FnOnce(&Self, &StackTrace) -> R,
     {
@@ -79,7 +79,7 @@ impl<'p> StackScope<'p> {
         mode: ScopeType,
         variables: HashMap<ImString, Value>,
         block: B,
-    ) -> ExpressionResult<R>
+    ) -> ExecutionResult<R>
     where
         B: FnOnce(&mut Self, &StackTrace) -> R,
     {
@@ -145,7 +145,7 @@ impl<'p> StackScope<'p> {
         stack_trace: &StackTrace,
         local_variables: impl IntoIterator<Item = ImString>,
         name: S,
-    ) -> ExpressionResult<&Value> {
+    ) -> ExecutionResult<&Value> {
         let name = name.into();
 
         let mut scope_iterator = self.iter_visible_scopes();

--- a/interpreter/src/execution/stack.rs
+++ b/interpreter/src/execution/stack.rs
@@ -19,7 +19,7 @@
 use crate::execution::logging::StackTrace;
 
 use super::{
-    errors::{ErrorType, ExecutionResult, Raise},
+    errors::{ExecutionResult, Raise},
     logging::LocatedStr,
     values::Value,
 };
@@ -204,7 +204,7 @@ struct NotInScopeError {
     suggestions: Vec<ImString>,
 }
 
-impl ErrorType for NotInScopeError {}
+impl std::error::Error for NotInScopeError {}
 
 impl Display for NotInScopeError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/interpreter/src/execution/stack.rs
+++ b/interpreter/src/execution/stack.rs
@@ -172,7 +172,11 @@ impl<'p> StackScope<'p> {
                 variable_name: ImString::from(name.string),
                 suggestions: self.suggest_similar_names(local_variables, name.string),
             }
-            .to_error(stack_trace.iter().chain([&name.location])))
+            .to_error(stack_trace.iter().chain([&StackTrace {
+                parent: None,
+                reference: name.location.clone(),
+                failure_message: None,
+            }])))
         }
     }
 }

--- a/interpreter/src/execution/store.rs
+++ b/interpreter/src/execution/store.rs
@@ -25,7 +25,7 @@ use sha2::{Digest, Sha256};
 use tempfile::{NamedTempFile, TempDir};
 
 use crate::{
-    execution::errors::{ErrorType, ExecutionResult, Raise},
+    execution::errors::{ExecutionResult, Raise},
     ExecutionContext,
 };
 
@@ -183,10 +183,12 @@ impl<A> std::ops::DerefMut for PendingAsset<A> {
     }
 }
 
+// We can probably remove that wrapper now.
+struct NoticeMe;
 #[derive(Debug)]
 pub struct IoError(pub std::io::Error);
 
-impl ErrorType for IoError {}
+impl std::error::Error for IoError {}
 
 impl std::fmt::Display for IoError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/interpreter/src/execution/store.rs
+++ b/interpreter/src/execution/store.rs
@@ -48,28 +48,25 @@ impl Store {
     ) -> ExecutionResult<PathBuf> {
         let store_path = self.generate_store_path(hashable, &name);
 
-        if std::fs::exists(&store_path)
-            .map_err(|error| IoError(error).to_error(context.stack_trace))?
-        {
+        if std::fs::exists(&store_path).map_err(|error| IoError(error).to_error(context))? {
             Ok(store_path)
         } else {
             // TODO should we be creating these in the project directory to increase the chances of
             // them being on the same filesystem as the store?
             let mut asset = PendingAsset {
                 store_path,
-                asset: NamedTempFile::new()
-                    .map_err(|error| IoError(error).to_error(context.stack_trace))?,
+                asset: NamedTempFile::new().map_err(|error| IoError(error).to_error(context))?,
             };
             init(&mut asset.asset)?;
 
             let (mut file, temp_path) = asset
                 .asset
                 .keep()
-                .map_err(|error| IoError(error.error).to_error(context.stack_trace))?;
+                .map_err(|error| IoError(error.error).to_error(context))?;
 
             // Make sure that file is flushed and closed.
             file.flush()
-                .map_err(|error| IoError(error).to_error(context.stack_trace))?;
+                .map_err(|error| IoError(error).to_error(context))?;
             drop(file);
 
             self.move_path_into_store(context, &temp_path, &asset.store_path)?;
@@ -87,17 +84,14 @@ impl Store {
     ) -> ExecutionResult<PathBuf> {
         let store_path = self.generate_store_path(hashable, &name);
 
-        if std::fs::exists(&store_path)
-            .map_err(|error| IoError(error).to_error(context.stack_trace))?
-        {
+        if std::fs::exists(&store_path).map_err(|error| IoError(error).to_error(context))? {
             Ok(store_path)
         } else {
             // TODO should we be creating these in the project directory to increase the chances of
             // them being on the same filesystem as the store?
             let mut asset = PendingAsset {
                 store_path,
-                asset: TempDir::new()
-                    .map_err(|error| IoError(error).to_error(context.stack_trace))?,
+                asset: TempDir::new().map_err(|error| IoError(error).to_error(context))?,
             };
             init(&mut asset.asset)?;
             let temp_path = asset.asset.keep();
@@ -157,7 +151,7 @@ impl Store {
                 result
             }
         }
-        .map_err(|error| IoError(error).to_error(context.stack_trace))?;
+        .map_err(|error| IoError(error).to_error(context))?;
 
         Ok(())
     }

--- a/interpreter/src/execution/store.rs
+++ b/interpreter/src/execution/store.rs
@@ -25,7 +25,7 @@ use sha2::{Digest, Sha256};
 use tempfile::{NamedTempFile, TempDir};
 
 use crate::{
-    execution::errors::{ErrorType, ExpressionResult, Raise},
+    execution::errors::{ErrorType, ExecutionResult, Raise},
     ExecutionContext,
 };
 
@@ -44,8 +44,8 @@ impl Store {
         context: &ExecutionContext,
         hashable: &impl std::hash::Hash,
         name: impl AsRef<str>,
-        init: impl FnOnce(&mut NamedTempFile) -> ExpressionResult<()>,
-    ) -> ExpressionResult<PathBuf> {
+        init: impl FnOnce(&mut NamedTempFile) -> ExecutionResult<()>,
+    ) -> ExecutionResult<PathBuf> {
         let store_path = self.generate_store_path(hashable, &name);
 
         if std::fs::exists(&store_path)
@@ -83,8 +83,8 @@ impl Store {
         context: &ExecutionContext,
         hashable: &impl std::hash::Hash,
         name: impl AsRef<str>,
-        init: impl FnOnce(&mut TempDir) -> ExpressionResult<()>,
-    ) -> ExpressionResult<PathBuf> {
+        init: impl FnOnce(&mut TempDir) -> ExecutionResult<()>,
+    ) -> ExecutionResult<PathBuf> {
         let store_path = self.generate_store_path(hashable, &name);
 
         if std::fs::exists(&store_path)
@@ -129,7 +129,7 @@ impl Store {
         context: &ExecutionContext,
         temp_path: &Path,
         store_path: &Path,
-    ) -> ExpressionResult<()> {
+    ) -> ExecutionResult<()> {
         // Move the file into the store.
         match std::fs::rename(temp_path, store_path) {
             Ok(_) => Ok(store_path),

--- a/interpreter/src/execution/store.rs
+++ b/interpreter/src/execution/store.rs
@@ -48,25 +48,24 @@ impl Store {
     ) -> ExecutionResult<PathBuf> {
         let store_path = self.generate_store_path(hashable, &name);
 
-        if std::fs::exists(&store_path).map_err(|error| IoError(error).to_error(context))? {
+        if std::fs::exists(&store_path).map_err(|error| error.to_error(context))? {
             Ok(store_path)
         } else {
             // TODO should we be creating these in the project directory to increase the chances of
             // them being on the same filesystem as the store?
             let mut asset = PendingAsset {
                 store_path,
-                asset: NamedTempFile::new().map_err(|error| IoError(error).to_error(context))?,
+                asset: NamedTempFile::new().map_err(|error| error.to_error(context))?,
             };
             init(&mut asset.asset)?;
 
             let (mut file, temp_path) = asset
                 .asset
                 .keep()
-                .map_err(|error| IoError(error.error).to_error(context))?;
+                .map_err(|error| error.error.to_error(context))?;
 
             // Make sure that file is flushed and closed.
-            file.flush()
-                .map_err(|error| IoError(error).to_error(context))?;
+            file.flush().map_err(|error| error.to_error(context))?;
             drop(file);
 
             self.move_path_into_store(context, &temp_path, &asset.store_path)?;
@@ -84,14 +83,14 @@ impl Store {
     ) -> ExecutionResult<PathBuf> {
         let store_path = self.generate_store_path(hashable, &name);
 
-        if std::fs::exists(&store_path).map_err(|error| IoError(error).to_error(context))? {
+        if std::fs::exists(&store_path).map_err(|error| error.to_error(context))? {
             Ok(store_path)
         } else {
             // TODO should we be creating these in the project directory to increase the chances of
             // them being on the same filesystem as the store?
             let mut asset = PendingAsset {
                 store_path,
-                asset: TempDir::new().map_err(|error| IoError(error).to_error(context))?,
+                asset: TempDir::new().map_err(|error| error.to_error(context))?,
             };
             init(&mut asset.asset)?;
             let temp_path = asset.asset.keep();
@@ -151,7 +150,7 @@ impl Store {
                 result
             }
         }
-        .map_err(|error| IoError(error).to_error(context))?;
+        .map_err(|error| error.to_error(context))?;
 
         Ok(())
     }

--- a/interpreter/src/execution/store.rs
+++ b/interpreter/src/execution/store.rs
@@ -177,19 +177,6 @@ impl<A> std::ops::DerefMut for PendingAsset<A> {
     }
 }
 
-// We can probably remove that wrapper now.
-struct NoticeMe;
-#[derive(Debug)]
-pub struct IoError(pub std::io::Error);
-
-impl std::error::Error for IoError {}
-
-impl std::fmt::Display for IoError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.0)
-    }
-}
-
 struct StoreHasher(Sha256);
 
 impl std::hash::Hasher for StoreHasher {

--- a/interpreter/src/execution/store.rs
+++ b/interpreter/src/execution/store.rs
@@ -46,32 +46,40 @@ impl Store {
         name: impl AsRef<str>,
         init: impl FnOnce(&mut NamedTempFile) -> ExecutionResult<()>,
     ) -> ExecutionResult<PathBuf> {
-        let store_path = self.generate_store_path(hashable, &name);
+        let name = name.as_ref();
 
-        if std::fs::exists(&store_path).map_err(|error| error.to_error(context))? {
-            Ok(store_path)
-        } else {
-            // TODO should we be creating these in the project directory to increase the chances of
-            // them being on the same filesystem as the store?
-            let mut asset = PendingAsset {
-                store_path,
-                asset: NamedTempFile::new().map_err(|error| error.to_error(context))?,
-            };
-            init(&mut asset.asset)?;
+        context.trace_scope(
+            Some(format!("Failed to fetch or create file {name} in store").into()),
+            context.stack_trace.bottom().clone(),
+            |context| {
+                let store_path = self.generate_store_path(hashable, name);
 
-            let (mut file, temp_path) = asset
-                .asset
-                .keep()
-                .map_err(|error| error.error.to_error(context))?;
+                if std::fs::exists(&store_path).map_err(|error| error.to_error(context))? {
+                    Ok(store_path)
+                } else {
+                    // TODO should we be creating these in the project directory to increase the chances of
+                    // them being on the same filesystem as the store?
+                    let mut asset = PendingAsset {
+                        store_path,
+                        asset: NamedTempFile::new().map_err(|error| error.to_error(context))?,
+                    };
+                    init(&mut asset.asset)?;
 
-            // Make sure that file is flushed and closed.
-            file.flush().map_err(|error| error.to_error(context))?;
-            drop(file);
+                    let (mut file, temp_path) = asset
+                        .asset
+                        .keep()
+                        .map_err(|error| error.error.to_error(context))?;
 
-            self.move_path_into_store(context, &temp_path, &asset.store_path)?;
+                    // Make sure that file is flushed and closed.
+                    file.flush().map_err(|error| error.to_error(context))?;
+                    drop(file);
 
-            Ok(asset.store_path)
-        }
+                    self.move_path_into_store(context, &temp_path, &asset.store_path)?;
+
+                    Ok(asset.store_path)
+                }
+            },
+        )
     }
 
     pub fn get_or_init_directory(
@@ -81,23 +89,31 @@ impl Store {
         name: impl AsRef<str>,
         init: impl FnOnce(&mut TempDir) -> ExecutionResult<()>,
     ) -> ExecutionResult<PathBuf> {
-        let store_path = self.generate_store_path(hashable, &name);
+        let name = name.as_ref();
 
-        if std::fs::exists(&store_path).map_err(|error| error.to_error(context))? {
-            Ok(store_path)
-        } else {
-            // TODO should we be creating these in the project directory to increase the chances of
-            // them being on the same filesystem as the store?
-            let mut asset = PendingAsset {
-                store_path,
-                asset: TempDir::new().map_err(|error| error.to_error(context))?,
-            };
-            init(&mut asset.asset)?;
-            let temp_path = asset.asset.keep();
-            self.move_path_into_store(context, &temp_path, &asset.store_path)?;
+        context.trace_scope(
+            Some(format!("Failed to fetch or create directory {name} in store").into()),
+            context.stack_trace.bottom().clone(),
+            |context| {
+                let store_path = self.generate_store_path(hashable, name);
 
-            Ok(asset.store_path)
-        }
+                if std::fs::exists(&store_path).map_err(|error| error.to_error(context))? {
+                    Ok(store_path)
+                } else {
+                    // TODO should we be creating these in the project directory to increase the chances of
+                    // them being on the same filesystem as the store?
+                    let mut asset = PendingAsset {
+                        store_path,
+                        asset: TempDir::new().map_err(|error| error.to_error(context))?,
+                    };
+                    init(&mut asset.asset)?;
+                    let temp_path = asset.asset.keep();
+                    self.move_path_into_store(context, &temp_path, &asset.store_path)?;
+
+                    Ok(asset.store_path)
+                }
+            },
+        )
     }
 
     fn generate_store_path(

--- a/interpreter/src/execution/values/boolean.rs
+++ b/interpreter/src/execution/values/boolean.rs
@@ -22,7 +22,7 @@ use crate::execution::{
     ExecutionContext,
 };
 
-use super::{value_type::ValueType, ExpressionResult, Object, StaticTypeName, Value};
+use super::{value_type::ValueType, ExecutionResult, Object, StaticTypeName, Value};
 
 use std::borrow::Cow;
 
@@ -60,26 +60,26 @@ impl Object for Boolean {
         write!(f, "{}", self.0)
     }
 
-    fn eq(self, context: &ExecutionContext, rhs: Value) -> ExpressionResult<bool> {
+    fn eq(self, context: &ExecutionContext, rhs: Value) -> ExecutionResult<bool> {
         let rhs: &Self = rhs.downcast_for_binary_op_ref(context.stack_trace)?;
         Ok(self.0 == rhs.0)
     }
-    fn and(self, context: &ExecutionContext, rhs: Value) -> ExpressionResult<Value> {
+    fn and(self, context: &ExecutionContext, rhs: Value) -> ExecutionResult<Value> {
         let rhs: &Self = rhs.downcast_for_binary_op_ref(context.stack_trace)?;
         Ok(Self(self.0 && rhs.0).into())
     }
 
-    fn or(self, context: &ExecutionContext, rhs: Value) -> ExpressionResult<Value> {
+    fn or(self, context: &ExecutionContext, rhs: Value) -> ExecutionResult<Value> {
         let rhs: &Self = rhs.downcast_for_binary_op_ref(context.stack_trace)?;
         Ok(Self(self.0 || rhs.0).into())
     }
 
-    fn xor(self, context: &ExecutionContext, rhs: Value) -> ExpressionResult<Value> {
+    fn xor(self, context: &ExecutionContext, rhs: Value) -> ExecutionResult<Value> {
         let rhs: &Self = rhs.downcast_for_binary_op_ref(context.stack_trace)?;
         Ok(Self((self.0 && rhs.0) || (!self.0 && !rhs.0)).into())
     }
 
-    fn unary_not(self, _context: &ExecutionContext) -> ExpressionResult<Value> {
+    fn unary_not(self, _context: &ExecutionContext) -> ExecutionResult<Value> {
         Ok(Self(!self.0).into())
     }
 }

--- a/interpreter/src/execution/values/boolean.rs
+++ b/interpreter/src/execution/values/boolean.rs
@@ -61,21 +61,21 @@ impl Object for Boolean {
     }
 
     fn eq(self, context: &ExecutionContext, rhs: Value) -> ExecutionResult<bool> {
-        let rhs: &Self = rhs.downcast_for_binary_op_ref(context.stack_trace)?;
+        let rhs: &Self = rhs.downcast_for_binary_op_ref(context)?;
         Ok(self.0 == rhs.0)
     }
     fn and(self, context: &ExecutionContext, rhs: Value) -> ExecutionResult<Value> {
-        let rhs: &Self = rhs.downcast_for_binary_op_ref(context.stack_trace)?;
+        let rhs: &Self = rhs.downcast_for_binary_op_ref(context)?;
         Ok(Self(self.0 && rhs.0).into())
     }
 
     fn or(self, context: &ExecutionContext, rhs: Value) -> ExecutionResult<Value> {
-        let rhs: &Self = rhs.downcast_for_binary_op_ref(context.stack_trace)?;
+        let rhs: &Self = rhs.downcast_for_binary_op_ref(context)?;
         Ok(Self(self.0 || rhs.0).into())
     }
 
     fn xor(self, context: &ExecutionContext, rhs: Value) -> ExecutionResult<Value> {
-        let rhs: &Self = rhs.downcast_for_binary_op_ref(context.stack_trace)?;
+        let rhs: &Self = rhs.downcast_for_binary_op_ref(context)?;
         Ok(Self((self.0 && rhs.0) || (!self.0 && !rhs.0)).into())
     }
 

--- a/interpreter/src/execution/values/closure.rs
+++ b/interpreter/src/execution/values/closure.rs
@@ -174,7 +174,7 @@ impl UserClosure {
         let return_type =
             context.trace_scope(source.node.return_type.reference.clone(), |context| {
                 execute_expression(context, &source.node.return_type)?
-                    .downcast::<ValueType>(context.stack_trace)
+                    .downcast::<ValueType>(context)
             })?;
 
         let signature = Arc::new(Signature {
@@ -439,14 +439,14 @@ macro_rules! build_function_callable {
                 signature
                     .argument_type
                     .check_other_qualifies(argument.struct_def())
-                    .map_err(|error| error.to_error($context.stack_trace.iter()))?;
+                    .map_err(|error| error.to_error($context))?;
 
                 // Argument is potentially unused if we take no arguments.
                 let mut _argument = signature.argument_type.fill_defaults(argument);
 
                 let _data = std::sync::Arc::make_mut(&mut _argument.data);
                 $($(let $arg: $ty = _data.members.remove(stringify!($arg))
-                        .expect("Argument was not present after argument check.").downcast::<$ty>($context.stack_trace)?;)*)?
+                        .expect("Argument was not present after argument check.").downcast::<$ty>($context)?;)*)?
 
                 let result: $return_type = {
                     $code?
@@ -518,19 +518,19 @@ macro_rules! build_method_callable {
                         location: $context.stack_trace.bottom().clone(),
                         string: "self",
                     },
-                )?.downcast_ref::<$this_type>($context.stack_trace)?.clone();
+                )?.downcast_ref::<$this_type>($context)?.clone();
 
                 signature
                     .argument_type
                     .check_other_qualifies(argument.struct_def())
-                    .map_err(|error| error.to_error($context.stack_trace.iter()))?;
+                    .map_err(|error| error.to_error($context))?;
 
                 // Argument is potentially unused if we take no arguments.
                 let mut _argument = signature.argument_type.fill_defaults(argument);
 
                 let _data = std::sync::Arc::make_mut(&mut _argument.data);
                 $($(let $arg: $ty = _data.members.remove(stringify!($arg))
-                        .expect("Argument was not present after argument check.").downcast::<$ty>($context.stack_trace)?;)*)?
+                        .expect("Argument was not present after argument check.").downcast::<$ty>($context)?;)*)?
 
                 let result: $return_type = {
                     $code?
@@ -936,7 +936,7 @@ mod test {
                 this: Dictionary,
                 to_add: UnsignedInteger
             ) -> UnsignedInteger {
-                let value: UnsignedInteger = this.get_attribute(context, "value")?.downcast(context.stack_trace)?;
+                let value: UnsignedInteger = this.get_attribute(context, "value")?.downcast(context)?;
 
                 Ok(values::UnsignedInteger::from(value.0 + to_add.0))
             }

--- a/interpreter/src/execution/values/closure.rs
+++ b/interpreter/src/execution/values/closure.rs
@@ -249,7 +249,7 @@ impl Object for UserClosure {
             .signature
             .argument_type
             .check_other_qualifies(argument.struct_def())
-            .map_err(|error| error.to_error(context.stack_trace))?;
+            .map_err(|error| error.to_error(context))?;
 
         let argument = self.data.signature.argument_type.fill_defaults(argument);
 
@@ -266,7 +266,7 @@ impl Object for UserClosure {
                 .signature
                 .return_type
                 .check_other_qualifies(&result.get_type(context))
-                .map_err(|error| error.to_error(context.stack_trace))?;
+                .map_err(|error| error.to_error(context))?;
 
             Ok(result)
         })?

--- a/interpreter/src/execution/values/closure.rs
+++ b/interpreter/src/execution/values/closure.rs
@@ -164,15 +164,18 @@ impl UserClosure {
         context: &ExecutionContext,
         source: &AstNode<Box<ClosureDefinition>>,
     ) -> ExecutionResult<Self> {
-        let argument_type =
-            context.trace_scope(source.node.argument_type.reference.clone(), |context| {
+        let argument_type = context.trace_scope(
+            None,
+            source.node.argument_type.reference.clone(),
+            |context| {
                 let argument_type = StructDefinition::new(context, &source.node.argument_type)?;
 
                 Ok(argument_type)
-            })?;
+            },
+        )?;
 
         let return_type =
-            context.trace_scope(source.node.return_type.reference.clone(), |context| {
+            context.trace_scope(None, source.node.return_type.reference.clone(), |context| {
                 execute_expression(context, &source.node.return_type)?
                     .downcast::<ValueType>(context)
             })?;

--- a/interpreter/src/execution/values/closure.rs
+++ b/interpreter/src/execution/values/closure.rs
@@ -620,9 +620,12 @@ impl StaticTypeName for BuiltinFunction {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::execution::{
-        test_context_custom_database, test_run,
-        values::{self, SignedInteger, StructMember, UnsignedInteger},
+    use crate::{
+        execution::{
+            test_context_custom_database, test_run,
+            values::{self, SignedInteger, StructMember, UnsignedInteger},
+        },
+        values::value_type::{MissmatchedField, TypeQualificationError},
     };
     use hashable_map::HashableMap;
     use pretty_assertions::assert_eq;
@@ -663,18 +666,41 @@ mod test {
 
     #[test]
     fn call_closure_bad_args() {
-        test_run(
+        let error = test_run(
             "let my_function = (a: std.types.UInt) -> std.types.UInt: a + 2u; in my_function(a = 3i)",
         )
         .unwrap_err();
+        let error = error.ty.as_any();
+        let error: &TypeQualificationError = error.downcast_ref().unwrap();
+        assert_eq!(
+            *error,
+            TypeQualificationError::Fields {
+                failed_feilds: vec![MissmatchedField {
+                    name: "a".into(),
+                    error: TypeQualificationError::This {
+                        expected: ValueType::UnsignedInteger,
+                        got: ValueType::SignedInteger,
+                    },
+                },],
+            }
+        );
     }
 
     #[test]
     fn call_closure_bad_result() {
-        test_run(
+        let error = test_run(
             "let my_function = (a: std.types.UInt) -> std.types.UInt: \"test\"; in my_function(a = 3u)",
         )
         .unwrap_err();
+        let error = error.ty.as_any();
+        let error: &TypeQualificationError = error.downcast_ref().unwrap();
+        assert_eq!(
+            *error,
+            TypeQualificationError::This {
+                expected: ValueType::UnsignedInteger,
+                got: ValueType::String
+            }
+        );
     }
 
     #[test]

--- a/interpreter/src/execution/values/constraint_set.rs
+++ b/interpreter/src/execution/values/constraint_set.rs
@@ -397,7 +397,7 @@ impl ConstraintSet {
                     variable_name,
                     Scalar {
                         dimension,
-                        value: Float::new(value).unwrap_not_nan(context.stack_trace)?,
+                        value: Float::new(value).unwrap_not_nan(context)?,
                     }
                     .into(),
                 );
@@ -610,7 +610,7 @@ pub fn register_methods(database: &mut BuiltinCallableDatabase) {
                     location: context.stack_trace.bottom().clone(),
                     string: "self",
                 })?
-                .downcast_ref::<ConstraintSet>(context.stack_trace)?
+                .downcast_ref::<ConstraintSet>(context)?
                 .clone();
 
             let solution = this.solve(context, argument)?;

--- a/interpreter/src/execution/values/constraint_set.rs
+++ b/interpreter/src/execution/values/constraint_set.rs
@@ -233,7 +233,7 @@ impl ConstraintSet {
             return Err(DuplicateVariablesError {
                 variables: duplicate_variables,
             }
-            .to_error(context.stack_trace));
+            .to_error(context));
         }
 
         let mut captured_values = HashMap::new();
@@ -329,7 +329,7 @@ impl Object for ConstraintSet {
             _ => Err(MissingAttributeError {
                 name: attribute.into(),
             }
-            .to_error(context.stack_trace)),
+            .to_error(context)),
         }
     }
 }
@@ -383,11 +383,10 @@ impl ConstraintSet {
         Self::build_relation(&mut m, &self.source.relation, left, right);
         let solution = m
             .solve()
-            .map_err(|error| SolverError(error).to_error(context.stack_trace))?;
+            .map_err(|error| SolverError(error).to_error(context))?;
 
         let dimension = dimension.ok_or_else(|| {
-            StrError("Could not determine dimension of constraint set")
-                .to_error(context.stack_trace)
+            StrError("Could not determine dimension of constraint set").to_error(context)
         })?;
 
         let mut members = HashMap::new();
@@ -471,7 +470,7 @@ impl ConstraintSet {
                                 "{} types are not supported in constraint sets",
                                 value.type_name()
                             ))
-                            .to_error(context.stack_trace)),
+                            .to_error(context)),
                         }
                     } else {
                         let variable = variables
@@ -524,7 +523,7 @@ impl ConstraintSet {
             ConstraintSetExpression::MethodCall(ast_node) => {
                 context.trace_scope(ast_node.reference.clone(), |context| {
                     Err(StrError("Methods are not yet supported in constraint sets")
-                        .to_error(context.stack_trace))
+                        .to_error(context))
                 })
             }
         }
@@ -540,7 +539,7 @@ impl ConstraintSet {
                 return Err(StrError(
                     "All measurements in constraint set must be of the same dimension",
                 )
-                .to_error(context.stack_trace));
+                .to_error(context));
             }
         } else if value.dimension != Dimension::zero() {
             *dimension = Some(value.dimension);

--- a/interpreter/src/execution/values/constraint_set.rs
+++ b/interpreter/src/execution/values/constraint_set.rs
@@ -30,7 +30,7 @@ use crate::{
         AstNode,
     },
     execution::{
-        errors::{ErrorType, ExecutionResult, GenericFailure, Raise},
+        errors::{ExecutionResult, GenericFailure, Raise},
         logging::LocatedStr,
     },
     values::{
@@ -566,7 +566,7 @@ struct DuplicateVariablesError {
     pub variables: Vec<ImString>,
 }
 
-impl ErrorType for DuplicateVariablesError {}
+impl std::error::Error for DuplicateVariablesError {}
 
 impl std::fmt::Display for DuplicateVariablesError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -592,7 +592,7 @@ impl std::fmt::Display for DuplicateVariablesError {
 #[derive(Debug)]
 struct SolverError(selen::api::SolverError);
 
-impl ErrorType for SolverError {}
+impl std::error::Error for SolverError {}
 
 impl std::fmt::Display for SolverError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/interpreter/src/execution/values/constraint_set.rs
+++ b/interpreter/src/execution/values/constraint_set.rs
@@ -30,7 +30,7 @@ use crate::{
         AstNode,
     },
     execution::{
-        errors::{ExecutionResult, GenericFailure, Raise},
+        errors::{ExecutionResult, Raise, StrError, StringError},
         logging::LocatedStr,
     },
     values::{
@@ -386,7 +386,7 @@ impl ConstraintSet {
             .map_err(|error| SolverError(error).to_error(context.stack_trace))?;
 
         let dimension = dimension.ok_or_else(|| {
-            GenericFailure("Could not determine dimension of constraint set".into())
+            StrError("Could not determine dimension of constraint set")
                 .to_error(context.stack_trace)
         })?;
 
@@ -467,13 +467,10 @@ impl ConstraintSet {
                             Value::Scalar(scalar) => {
                                 Self::build_scalar(context, dimension, *scalar)
                             }
-                            value => Err(GenericFailure(
-                                format!(
-                                    "{} types are not supported in constraint sets",
-                                    value.type_name()
-                                )
-                                .into(),
-                            )
+                            value => Err(StringError(format!(
+                                "{} types are not supported in constraint sets",
+                                value.type_name()
+                            ))
                             .to_error(context.stack_trace)),
                         }
                     } else {
@@ -526,10 +523,8 @@ impl ConstraintSet {
             }
             ConstraintSetExpression::MethodCall(ast_node) => {
                 context.trace_scope(ast_node.reference.clone(), |context| {
-                    Err(
-                        GenericFailure("Methods are not yet supported in constraint sets".into())
-                            .to_error(context.stack_trace),
-                    )
+                    Err(StrError("Methods are not yet supported in constraint sets")
+                        .to_error(context.stack_trace))
                 })
             }
         }
@@ -542,8 +537,8 @@ impl ConstraintSet {
     ) -> ExecutionResult<ExprBuilder> {
         if let Some(dimension) = dimension {
             if value.dimension != Dimension::zero() && *dimension != value.dimension {
-                return Err(GenericFailure(
-                    "All measurements in constraint set must be of the same dimension".into(),
+                return Err(StrError(
+                    "All measurements in constraint set must be of the same dimension",
                 )
                 .to_error(context.stack_trace));
             }

--- a/interpreter/src/execution/values/constraint_set.rs
+++ b/interpreter/src/execution/values/constraint_set.rs
@@ -451,12 +451,12 @@ impl ConstraintSet {
                     value: ast_node.node.value,
                 };
 
-                context.trace_scope(ast_node.reference.clone(), |context| {
+                context.trace_scope(None, ast_node.reference.clone(), |context| {
                     Self::build_scalar(context, dimension, value)
                 })
             }
             ConstraintSetExpression::Identifier(ast_node) => {
-                context.trace_scope(ast_node.reference.clone(), |context| {
+                context.trace_scope(None, ast_node.reference.clone(), |context| {
                     let name = &ast_node.node;
                     if let Some(value) = value_provider
                         .get(name)
@@ -521,7 +521,7 @@ impl ConstraintSet {
                 }
             }
             ConstraintSetExpression::MethodCall(ast_node) => {
-                context.trace_scope(ast_node.reference.clone(), |context| {
+                context.trace_scope(None, ast_node.reference.clone(), |context| {
                     Err(StrError("Methods are not yet supported in constraint sets")
                         .to_error(context))
                 })

--- a/interpreter/src/execution/values/dictionary.rs
+++ b/interpreter/src/execution/values/dictionary.rs
@@ -26,7 +26,7 @@ use crate::{
     compile::{AstNode, DictionaryConstruction},
     execute_expression,
     execution::{
-        errors::{ErrorType, ExpressionResult, Raise as _},
+        errors::{ErrorType, ExecutionResult, Raise as _},
         find_all_variable_accesses_in_expression,
         stack::ScopeType,
         values::string::formatting::Style,
@@ -53,8 +53,8 @@ impl PartialEq for DictionaryData {
 
 pub fn find_all_variable_accesses_in_dictionary_construction(
     dictionary_construction: &crate::compile::DictionaryConstruction,
-    access_collector: &mut dyn FnMut(&AstNode<ImString>) -> ExpressionResult<()>,
-) -> ExpressionResult<()> {
+    access_collector: &mut dyn FnMut(&AstNode<ImString>) -> ExecutionResult<()>,
+) -> ExecutionResult<()> {
     for assignment in dictionary_construction.assignments.iter() {
         find_all_variable_accesses_in_expression(
             &assignment.node.assignment.node,
@@ -99,11 +99,7 @@ impl Object for Dictionary {
         Ok(())
     }
 
-    fn get_attribute(
-        &self,
-        context: &ExecutionContext,
-        attribute: &str,
-    ) -> ExpressionResult<Value> {
+    fn get_attribute(&self, context: &ExecutionContext, attribute: &str) -> ExecutionResult<Value> {
         if let Some(member) = self.data.members.get(attribute) {
             Ok(member.clone())
         } else {
@@ -141,7 +137,7 @@ impl Dictionary {
     pub fn from_ast(
         context: &ExecutionContext,
         ast_node: &AstNode<DictionaryConstruction>,
-    ) -> ExpressionResult<Self> {
+    ) -> ExecutionResult<Self> {
         let mut members = HashMap::with_capacity(ast_node.node.assignments.len());
 
         context.stack.scope_mut(

--- a/interpreter/src/execution/values/dictionary.rs
+++ b/interpreter/src/execution/values/dictionary.rs
@@ -106,7 +106,7 @@ impl Object for Dictionary {
             Err(MissingAttributeError {
                 name: attribute.into(),
             }
-            .to_error(context.stack_trace))
+            .to_error(context))
         }
     }
 }

--- a/interpreter/src/execution/values/dictionary.rs
+++ b/interpreter/src/execution/values/dictionary.rs
@@ -26,7 +26,7 @@ use crate::{
     compile::{AstNode, DictionaryConstruction},
     execute_expression,
     execution::{
-        errors::{ErrorType, ExecutionResult, Raise as _},
+        errors::{ExecutionResult, Raise as _},
         find_all_variable_accesses_in_expression,
         stack::ScopeType,
         values::string::formatting::Style,
@@ -221,7 +221,7 @@ pub struct DuplicateMemberError {
     pub name: ImString,
 }
 
-impl ErrorType for DuplicateMemberError {}
+impl std::error::Error for DuplicateMemberError {}
 
 impl Display for DuplicateMemberError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/interpreter/src/execution/values/dictionary.rs
+++ b/interpreter/src/execution/values/dictionary.rs
@@ -33,6 +33,7 @@ use crate::{
         ExecutionContext,
     },
     values::StaticType,
+    StackTrace,
 };
 
 use super::{
@@ -168,7 +169,11 @@ impl Dictionary {
                         if members.insert(name.clone(), value.clone()).is_some() {
                             // That's a duplicate member.
                             return Err(DuplicateMemberError { name }.to_error(
-                                context.stack_trace.iter().chain([&ast_node.reference]),
+                                context.stack_trace.iter().chain([&StackTrace {
+                                    parent: None,
+                                    reference: ast_node.reference.clone(),
+                                    failure_message: None,
+                                }]),
                             ));
                         }
 

--- a/interpreter/src/execution/values/dictionary.rs
+++ b/interpreter/src/execution/values/dictionary.rs
@@ -264,12 +264,18 @@ mod test {
     #[test]
     fn duplicate_entries() {
         // Two values of the same name is not allowed.
-        test_run("(void = (), void = ())").unwrap_err();
+        let error = test_run("(void = (), void = ())").unwrap_err();
+        let error = error.ty.as_any();
+        let error: &DuplicateMemberError = error.downcast_ref().unwrap();
+        assert_eq!(error.name, "void");
     }
 
     #[test]
     fn non_existant_member() {
-        test_run("(void = ()).does_not_exist").unwrap_err();
+        let error = test_run("(void = ()).does_not_exist").unwrap_err();
+        let error = error.ty.as_any();
+        let error: &MissingAttributeError = error.downcast_ref().unwrap();
+        assert_eq!(error.name, "does_not_exist");
     }
 
     #[test]

--- a/interpreter/src/execution/values/file.rs
+++ b/interpreter/src/execution/values/file.rs
@@ -23,7 +23,7 @@ use imstr::ImString;
 use crate::{
     build_method,
     execution::{
-        errors::GenericFailure,
+        errors::StringError,
         logging::{LogLevel, LogMessage},
         values::{
             string::formatting::Style, BuiltinCallableDatabase, IString, Object, StaticTypeName,
@@ -103,7 +103,7 @@ pub fn register_methods(database: &mut BuiltinCallableDatabase) {
             this: File
         ) -> IString {
             let content = std::fs::read_to_string(this.path.as_path())
-                .map_err(|error| GenericFailure(format!("Failed to read file to string: {error:?}").into()).to_error(context.stack_trace))?;
+                .map_err(|error| StringError(format!("Failed to read file to string: {error:?}")).to_error(context.stack_trace))?;
 
             Ok(IString(ImString::from(content)))
         }

--- a/interpreter/src/execution/values/file.rs
+++ b/interpreter/src/execution/values/file.rs
@@ -103,7 +103,7 @@ pub fn register_methods(database: &mut BuiltinCallableDatabase) {
             this: File
         ) -> IString {
             let content = std::fs::read_to_string(this.path.as_path())
-                .map_err(|error| StringError(format!("Failed to read file to string: {error:?}")).to_error(context.stack_trace))?;
+                .map_err(|error| StringError(format!("Failed to read file to string: {error:?}")).to_error(context))?;
 
             Ok(IString(ImString::from(content)))
         }

--- a/interpreter/src/execution/values/file.rs
+++ b/interpreter/src/execution/values/file.rs
@@ -23,7 +23,6 @@ use imstr::ImString;
 use crate::{
     build_method,
     execution::{
-        errors::StringError,
         logging::{LogLevel, LogMessage},
         values::{
             string::formatting::Style, BuiltinCallableDatabase, IString, Object, StaticTypeName,
@@ -102,10 +101,12 @@ pub fn register_methods(database: &mut BuiltinCallableDatabase) {
             context: &ExecutionContext,
             this: File
         ) -> IString {
-            let content = std::fs::read_to_string(this.path.as_path())
-                .map_err(|error| StringError(format!("Failed to read file to string: {error:?}")).to_error(context))?;
+            context.trace_scope(Some("Failed to read file to string".into()), context.stack_trace.bottom().clone(), |context| {
+                let content = std::fs::read_to_string(this.path.as_path())
+                    .map_err(|error| error.to_error(context))?;
 
-            Ok(IString(ImString::from(content)))
+                Ok(IString(ImString::from(content)))
+            })
         }
     );
 }

--- a/interpreter/src/execution/values/integer.rs
+++ b/interpreter/src/execution/values/integer.rs
@@ -118,24 +118,24 @@ where
     }
 
     fn bit_and(self, context: &ExecutionContext, rhs: Value) -> ExecutionResult<Value> {
-        let rhs: &Self = rhs.downcast_for_binary_op_ref(context.stack_trace)?;
+        let rhs: &Self = rhs.downcast_for_binary_op_ref(context)?;
         Ok(Self(self.0 & rhs.0).into())
     }
     fn bit_or(self, context: &ExecutionContext, rhs: Value) -> ExecutionResult<Value> {
-        let rhs: &Self = rhs.downcast_for_binary_op_ref(context.stack_trace)?;
+        let rhs: &Self = rhs.downcast_for_binary_op_ref(context)?;
         Ok(Self(self.0 | rhs.0).into())
     }
     fn bit_xor(self, context: &ExecutionContext, rhs: Value) -> ExecutionResult<Value> {
-        let rhs: &Self = rhs.downcast_for_binary_op_ref(context.stack_trace)?;
+        let rhs: &Self = rhs.downcast_for_binary_op_ref(context)?;
         Ok(Self(self.0 ^ rhs.0).into())
     }
 
     fn cmp(self, context: &ExecutionContext, rhs: Value) -> ExecutionResult<Ordering> {
-        let rhs: &Self = rhs.downcast_for_binary_op_ref(context.stack_trace)?;
+        let rhs: &Self = rhs.downcast_for_binary_op_ref(context)?;
         Ok(self.0.cmp(&rhs.0))
     }
     fn addition(self, context: &ExecutionContext, rhs: Value) -> ExecutionResult<Value> {
-        let rhs: &Self = rhs.downcast_for_binary_op_ref(context.stack_trace)?;
+        let rhs: &Self = rhs.downcast_for_binary_op_ref(context)?;
         Ok(Self(self.0.checked_add(&rhs.0).ok_or_else(|| {
             StrError("Integer overflow: The computed value is too large to store in the integer")
                 .to_error(context)
@@ -143,7 +143,7 @@ where
         .into())
     }
     fn subtraction(self, context: &ExecutionContext, rhs: Value) -> ExecutionResult<Value> {
-        let rhs: &Self = rhs.downcast_for_binary_op_ref(context.stack_trace)?;
+        let rhs: &Self = rhs.downcast_for_binary_op_ref(context)?;
         Ok(Self(self.0.checked_sub(&rhs.0).ok_or_else(|| {
             StrError("Integer underflow: The computed value is too small to store in the integer")
                 .to_error(context)
@@ -151,7 +151,7 @@ where
         .into())
     }
     fn multiply(self, context: &ExecutionContext, rhs: Value) -> ExecutionResult<Value> {
-        let rhs: &Self = rhs.downcast_for_binary_op_ref(context.stack_trace)?;
+        let rhs: &Self = rhs.downcast_for_binary_op_ref(context)?;
         Ok(Self(self.0.checked_mul(&rhs.0).ok_or_else(|| {
             StrError("Integer overflow: The computed value is too large to store in the integer")
                 .to_error(context)
@@ -159,7 +159,7 @@ where
         .into())
     }
     fn divide(self, context: &ExecutionContext, rhs: Value) -> ExecutionResult<Value> {
-        let rhs: &Self = rhs.downcast_for_binary_op_ref(context.stack_trace)?;
+        let rhs: &Self = rhs.downcast_for_binary_op_ref(context)?;
         Ok(Self(
             self.0
                 .checked_div(&rhs.0)
@@ -168,7 +168,7 @@ where
         .into())
     }
     fn exponent(self, context: &ExecutionContext, rhs: Value) -> ExecutionResult<Value> {
-        let rhs: &Self = rhs.downcast_for_binary_op_ref(context.stack_trace)?;
+        let rhs: &Self = rhs.downcast_for_binary_op_ref(context)?;
 
         // This failure can only happen on 32bit (or less) systems.
         let rhs = rhs.0.to_usize().ok_or_else(|| {
@@ -183,11 +183,11 @@ where
         .into())
     }
     fn left_shift(self, context: &ExecutionContext, rhs: Value) -> ExecutionResult<Value> {
-        let rhs: &Self = rhs.downcast_for_binary_op_ref(context.stack_trace)?;
+        let rhs: &Self = rhs.downcast_for_binary_op_ref(context)?;
         Ok(Self(self.0 << rhs.0).into())
     }
     fn right_shift(self, context: &ExecutionContext, rhs: Value) -> ExecutionResult<Value> {
-        let rhs: &Self = rhs.downcast_for_binary_op_ref(context.stack_trace)?;
+        let rhs: &Self = rhs.downcast_for_binary_op_ref(context)?;
         Ok(Self(self.0 >> rhs.0).into())
     }
     fn unary_plus(self, _context: &ExecutionContext) -> ExecutionResult<Value> {

--- a/interpreter/src/execution/values/integer.rs
+++ b/interpreter/src/execution/values/integer.rs
@@ -138,7 +138,7 @@ where
         let rhs: &Self = rhs.downcast_for_binary_op_ref(context.stack_trace)?;
         Ok(Self(self.0.checked_add(&rhs.0).ok_or_else(|| {
             StrError("Integer overflow: The computed value is too large to store in the integer")
-                .to_error(context.stack_trace)
+                .to_error(context)
         })?)
         .into())
     }
@@ -146,7 +146,7 @@ where
         let rhs: &Self = rhs.downcast_for_binary_op_ref(context.stack_trace)?;
         Ok(Self(self.0.checked_sub(&rhs.0).ok_or_else(|| {
             StrError("Integer underflow: The computed value is too small to store in the integer")
-                .to_error(context.stack_trace)
+                .to_error(context)
         })?)
         .into())
     }
@@ -154,7 +154,7 @@ where
         let rhs: &Self = rhs.downcast_for_binary_op_ref(context.stack_trace)?;
         Ok(Self(self.0.checked_mul(&rhs.0).ok_or_else(|| {
             StrError("Integer overflow: The computed value is too large to store in the integer")
-                .to_error(context.stack_trace)
+                .to_error(context)
         })?)
         .into())
     }
@@ -163,7 +163,7 @@ where
         Ok(Self(
             self.0
                 .checked_div(&rhs.0)
-                .ok_or_else(|| StrError("The computed value is either too large to store in the integer or you attempted to divide by zero").to_error(context.stack_trace))?,
+                .ok_or_else(|| StrError("The computed value is either too large to store in the integer or you attempted to divide by zero").to_error(context))?,
         )
         .into())
     }
@@ -173,12 +173,12 @@ where
         // This failure can only happen on 32bit (or less) systems.
         let rhs = rhs.0.to_usize().ok_or_else(|| {
             StrError("Integer overflow: The requested exponent is larger than the host machine word size")
-                .to_error(context.stack_trace)
+                .to_error(context)
         })?;
 
         Ok(Self(checked_pow(self.0, rhs).ok_or_else(|| {
             StrError("Integer overflow: The computed value is too large to store in the integer")
-                .to_error(context.stack_trace)
+                .to_error(context)
         })?)
         .into())
     }
@@ -268,7 +268,7 @@ where
             _ => Err(MissingAttributeError {
                 name: attribute.into(),
             }
-            .to_error(context.stack_trace)),
+            .to_error(context)),
         }
     }
 }
@@ -794,15 +794,15 @@ pub fn register_methods_and_functions(database: &mut BuiltinCallableDatabase) {
             let end = end.0;
 
             if inclusive && reverse && end == 0 {
-                return Err(StrError("Range ending will be less than zero, which is not possible for an unsigned integer").to_error(context.stack_trace));
+                return Err(StrError("Range ending will be less than zero, which is not possible for an unsigned integer").to_error(context));
             }
 
             if reverse {
                 if start < end {
-                    return Err(StrError("Start cannot be less than end when iterating a reversed range").to_error(context.stack_trace));
+                    return Err(StrError("Start cannot be less than end when iterating a reversed range").to_error(context));
                 }
             } else if start > end {
-                return Err(StrError("Start cannot be greater than end when iterating a range").to_error(context.stack_trace));
+                return Err(StrError("Start cannot be greater than end when iterating a range").to_error(context));
             }
 
             Ok(ValueIterator::new(Range { start, end, inclusive, reverse }))
@@ -824,10 +824,10 @@ pub fn register_methods_and_functions(database: &mut BuiltinCallableDatabase) {
 
             if reverse {
                 if start < end {
-                    return Err(StrError("Start cannot be less than end when iterating a reversed range").to_error(context.stack_trace));
+                    return Err(StrError("Start cannot be less than end when iterating a reversed range").to_error(context));
                 }
             } else if start > end {
-                return Err(StrError("Start cannot be greater than end when iterating a range").to_error(context.stack_trace));
+                return Err(StrError("Start cannot be greater than end when iterating a range").to_error(context));
             }
 
             Ok(ValueIterator::new(Range { start, end, inclusive, reverse }))

--- a/interpreter/src/execution/values/integer.rs
+++ b/interpreter/src/execution/values/integer.rs
@@ -30,7 +30,7 @@ use std::{
 use crate::{
     build_function,
     execution::{
-        errors::{ExecutionResult, GenericFailure, Raise},
+        errors::{ExecutionResult, Raise, StrError},
         logging::{LogLevel, LogMessage, StackTrace},
         values::{
             closure::BuiltinCallableDatabase, integer::methods::MethodSet,
@@ -137,30 +137,24 @@ where
     fn addition(self, context: &ExecutionContext, rhs: Value) -> ExecutionResult<Value> {
         let rhs: &Self = rhs.downcast_for_binary_op_ref(context.stack_trace)?;
         Ok(Self(self.0.checked_add(&rhs.0).ok_or_else(|| {
-            GenericFailure(
-                "Integer overflow: The computed value is too large to store in the integer".into(),
-            )
-            .to_error(context.stack_trace)
+            StrError("Integer overflow: The computed value is too large to store in the integer")
+                .to_error(context.stack_trace)
         })?)
         .into())
     }
     fn subtraction(self, context: &ExecutionContext, rhs: Value) -> ExecutionResult<Value> {
         let rhs: &Self = rhs.downcast_for_binary_op_ref(context.stack_trace)?;
         Ok(Self(self.0.checked_sub(&rhs.0).ok_or_else(|| {
-            GenericFailure(
-                "Integer underflow: The computed value is too small to store in the integer".into(),
-            )
-            .to_error(context.stack_trace)
+            StrError("Integer underflow: The computed value is too small to store in the integer")
+                .to_error(context.stack_trace)
         })?)
         .into())
     }
     fn multiply(self, context: &ExecutionContext, rhs: Value) -> ExecutionResult<Value> {
         let rhs: &Self = rhs.downcast_for_binary_op_ref(context.stack_trace)?;
         Ok(Self(self.0.checked_mul(&rhs.0).ok_or_else(|| {
-            GenericFailure(
-                "Integer overflow: The computed value is too large to store in the integer".into(),
-            )
-            .to_error(context.stack_trace)
+            StrError("Integer overflow: The computed value is too large to store in the integer")
+                .to_error(context.stack_trace)
         })?)
         .into())
     }
@@ -169,7 +163,7 @@ where
         Ok(Self(
             self.0
                 .checked_div(&rhs.0)
-                .ok_or_else(|| GenericFailure("The computed value is either too large to store in the integer or you attempted to divide by zero".into()).to_error(context.stack_trace))?,
+                .ok_or_else(|| StrError("The computed value is either too large to store in the integer or you attempted to divide by zero").to_error(context.stack_trace))?,
         )
         .into())
     }
@@ -178,17 +172,13 @@ where
 
         // This failure can only happen on 32bit (or less) systems.
         let rhs = rhs.0.to_usize().ok_or_else(|| {
-            GenericFailure(
-                "Integer overflow: The requested exponent is larger than the host machine word size".into(),
-            )
-            .to_error(context.stack_trace)
+            StrError("Integer overflow: The requested exponent is larger than the host machine word size")
+                .to_error(context.stack_trace)
         })?;
 
         Ok(Self(checked_pow(self.0, rhs).ok_or_else(|| {
-            GenericFailure(
-                "Integer overflow: The computed value is too large to store in the integer".into(),
-            )
-            .to_error(context.stack_trace)
+            StrError("Integer overflow: The computed value is too large to store in the integer")
+                .to_error(context.stack_trace)
         })?)
         .into())
     }
@@ -804,15 +794,15 @@ pub fn register_methods_and_functions(database: &mut BuiltinCallableDatabase) {
             let end = end.0;
 
             if inclusive && reverse && end == 0 {
-                return Err(GenericFailure("Range ending will be less than zero, which is not possible for an unsigned integer".into()).to_error(context.stack_trace));
+                return Err(StrError("Range ending will be less than zero, which is not possible for an unsigned integer").to_error(context.stack_trace));
             }
 
             if reverse {
                 if start < end {
-                    return Err(GenericFailure("Start cannot be less than end when iterating a reversed range".into()).to_error(context.stack_trace));
+                    return Err(StrError("Start cannot be less than end when iterating a reversed range").to_error(context.stack_trace));
                 }
             } else if start > end {
-                return Err(GenericFailure("Start cannot be greater than end when iterating a range".into()).to_error(context.stack_trace));
+                return Err(StrError("Start cannot be greater than end when iterating a range").to_error(context.stack_trace));
             }
 
             Ok(ValueIterator::new(Range { start, end, inclusive, reverse }))
@@ -834,10 +824,10 @@ pub fn register_methods_and_functions(database: &mut BuiltinCallableDatabase) {
 
             if reverse {
                 if start < end {
-                    return Err(GenericFailure("Start cannot be less than end when iterating a reversed range".into()).to_error(context.stack_trace));
+                    return Err(StrError("Start cannot be less than end when iterating a reversed range").to_error(context.stack_trace));
                 }
             } else if start > end {
-                return Err(GenericFailure("Start cannot be greater than end when iterating a range".into()).to_error(context.stack_trace));
+                return Err(StrError("Start cannot be greater than end when iterating a range").to_error(context.stack_trace));
             }
 
             Ok(ValueIterator::new(Range { start, end, inclusive, reverse }))

--- a/interpreter/src/execution/values/integer.rs
+++ b/interpreter/src/execution/values/integer.rs
@@ -893,7 +893,10 @@ where
 
 #[cfg(test)]
 mod test {
-    use crate::execution::{test_run, values::Boolean};
+    use crate::{
+        execution::{test_run, values::Boolean},
+        values::UnsupportedOperationError,
+    };
 
     use super::*;
 
@@ -1141,7 +1144,10 @@ mod test {
 
     #[test]
     fn unsigned_unary_minus() {
-        test_run("-3u").unwrap_err();
+        let error = test_run("-3u").unwrap_err();
+        let error = error.ty.as_any();
+        let error: &UnsupportedOperationError = error.downcast_ref().unwrap();
+        assert_eq!(error.operation_name, "negate");
     }
 
     #[test]

--- a/interpreter/src/execution/values/iterators.rs
+++ b/interpreter/src/execution/values/iterators.rs
@@ -147,7 +147,7 @@ impl Object for ValueIterator {
             _ => Err(MissingAttributeError {
                 name: attribute.into(),
             }
-            .to_error(context.stack_trace)),
+            .to_error(context)),
         }
     }
 }

--- a/interpreter/src/execution/values/iterators.rs
+++ b/interpreter/src/execution/values/iterators.rs
@@ -341,7 +341,7 @@ impl IteratorStage {
                                     HashMap::from_iter([("c".into(), value.clone())]),
                                 ),
                             )
-                            .and_then(|value| value.downcast::<Boolean>(context.stack_trace));
+                            .and_then(|value| value.downcast::<Boolean>(context));
 
                         match result {
                             Ok(keep) => {
@@ -399,7 +399,7 @@ impl IteratorStage {
                 ) -> ExecutionResult<R> {
                     if let Some(result) = iterators.next() {
                         let value = result?;
-                        let sub_iterator: ValueIterator = value.downcast(context.stack_trace)?;
+                        let sub_iterator: ValueIterator = value.downcast(context)?;
 
                         sub_iterator.iterate(
                             context,
@@ -474,7 +474,7 @@ impl IteratorStage {
                                 HashMap::from_iter([("c".into(), value.clone())]),
                             ),
                         )
-                        .and_then(|value| value.downcast::<Boolean>(context.stack_trace))?
+                        .and_then(|value| value.downcast::<Boolean>(context))?
                         .0;
 
                     if !should_skip {
@@ -505,7 +505,7 @@ impl IteratorStage {
                                     HashMap::from_iter([("c".into(), value.clone())]),
                                 ),
                             )
-                            .and_then(|value| value.downcast::<Boolean>(context.stack_trace));
+                            .and_then(|value| value.downcast::<Boolean>(context));
 
                         match result {
                             Ok(should_continue) => {
@@ -802,7 +802,7 @@ pub fn register_methods(database: &mut BuiltinCallableDatabase) {
                                 HashMap::from_iter([("c".into(), value.clone())]),
                             ),
                         )
-                        .and_then(|value| value.downcast::<Boolean>(context.stack_trace))?;
+                        .and_then(|value| value.downcast::<Boolean>(context))?;
 
                     if !passes.0 {
                         return Ok(Boolean(false));
@@ -834,7 +834,7 @@ pub fn register_methods(database: &mut BuiltinCallableDatabase) {
                                 HashMap::from_iter([("c".into(), value.clone())]),
                             ),
                         )
-                        .and_then(|value| value.downcast::<Boolean>(context.stack_trace))?;
+                        .and_then(|value| value.downcast::<Boolean>(context))?;
 
                     if passes.0 {
                         return Ok(Boolean(true));
@@ -868,7 +868,7 @@ pub fn register_methods(database: &mut BuiltinCallableDatabase) {
 
                 for value in iterator {
                     let value = value?;
-                    let string: IString = value.downcast(context.stack_trace)?;
+                    let string: IString = value.downcast(context)?;
 
                     collected += string.0.as_str();
                 }

--- a/interpreter/src/execution/values/list.rs
+++ b/interpreter/src/execution/values/list.rs
@@ -146,7 +146,7 @@ impl Object for List {
     }
 
     fn eq(self, context: &ExecutionContext, rhs: Value) -> ExecutionResult<bool> {
-        let rhs: &Self = rhs.downcast_for_binary_op_ref(context.stack_trace)?;
+        let rhs: &Self = rhs.downcast_for_binary_op_ref(context)?;
         Ok(self.values == rhs.values)
     }
 
@@ -481,7 +481,7 @@ pub fn register_methods(database: &mut BuiltinCallableDatabase) {
                         "c".into(),
                         value.clone()
                     )
-                ])))?.downcast::<Boolean>(context.stack_trace)?;
+                ])))?.downcast::<Boolean>(context)?;
 
                 if retain.0 {
                     values.push(value.clone());

--- a/interpreter/src/execution/values/list.rs
+++ b/interpreter/src/execution/values/list.rs
@@ -21,7 +21,7 @@ use crate::{
     compile::{AstNode, Expression},
     execute_expression,
     execution::{
-        errors::{Error, GenericFailure, Raise as _},
+        errors::{Error, Raise as _, StrError},
         values::{
             closure::BuiltinCallableDatabase, string::formatting::Style, Boolean, BuiltinFunction,
             Dictionary, MissingAttributeError, StaticType, UnsignedInteger, ValueNone,
@@ -420,7 +420,7 @@ pub fn register_methods(database: &mut BuiltinCallableDatabase) {
             if let Some(slice) = slice {
                 Ok(List::from_iter(context, slice.iter().cloned()))
             } else {
-                Err(GenericFailure("Slice out of range".into()).to_error(context.stack_trace))
+                Err(StrError("Slice out of range").to_error(context.stack_trace))
             }
         }
     );
@@ -436,7 +436,7 @@ pub fn register_methods(database: &mut BuiltinCallableDatabase) {
             if let Some(slice) = slice {
                 Ok(slice.clone())
             } else {
-                Err(GenericFailure("Index out of range".into()).to_error(context.stack_trace))
+                Err(StrError("Index out of range").to_error(context.stack_trace))
             }
         }
     );

--- a/interpreter/src/execution/values/list.rs
+++ b/interpreter/src/execution/values/list.rs
@@ -21,7 +21,7 @@ use crate::{
     compile::{AstNode, Expression},
     execute_expression,
     execution::{
-        errors::{Error, ErrorType, GenericFailure, Raise as _},
+        errors::{Error, GenericFailure, Raise as _},
         values::{
             closure::BuiltinCallableDatabase, string::formatting::Style, Boolean, BuiltinFunction,
             Dictionary, MissingAttributeError, StaticType, UnsignedInteger, ValueNone,
@@ -311,7 +311,7 @@ struct OperationMappingError {
     pub error: Error,
 }
 
-impl ErrorType for OperationMappingError {}
+impl std::error::Error for OperationMappingError {}
 
 impl std::fmt::Display for OperationMappingError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -328,7 +328,7 @@ struct SortingError {
     pub errors: Vec<Error>,
 }
 
-impl ErrorType for SortingError {}
+impl std::error::Error for SortingError {}
 
 impl std::fmt::Display for SortingError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/interpreter/src/execution/values/list.rs
+++ b/interpreter/src/execution/values/list.rs
@@ -101,7 +101,7 @@ impl List {
                 })
             })
             .collect::<Result<_, OperationMappingError>>()
-            .map_err(|error| error.to_error(context.stack_trace))?;
+            .map_err(|error| error.to_error(context))?;
 
         Ok(Self::from_iter(context, values))
     }
@@ -176,7 +176,7 @@ impl Object for List {
             _ => Err(MissingAttributeError {
                 name: attribute.into(),
             }
-            .to_error(context.stack_trace)),
+            .to_error(context)),
         }
     }
 
@@ -420,7 +420,7 @@ pub fn register_methods(database: &mut BuiltinCallableDatabase) {
             if let Some(slice) = slice {
                 Ok(List::from_iter(context, slice.iter().cloned()))
             } else {
-                Err(StrError("Slice out of range").to_error(context.stack_trace))
+                Err(StrError("Slice out of range").to_error(context))
             }
         }
     );
@@ -436,7 +436,7 @@ pub fn register_methods(database: &mut BuiltinCallableDatabase) {
             if let Some(slice) = slice {
                 Ok(slice.clone())
             } else {
-                Err(StrError("Index out of range").to_error(context.stack_trace))
+                Err(StrError("Index out of range").to_error(context))
             }
         }
     );
@@ -513,7 +513,7 @@ pub fn register_methods(database: &mut BuiltinCallableDatabase) {
             if errors.is_empty() {
                 Ok(List::from_iter(context, values.into_iter()))
             } else {
-                Err(SortingError { errors }.to_error(context.stack_trace))
+                Err(SortingError { errors }.to_error(context))
             }
         }
     );

--- a/interpreter/src/execution/values/list.rs
+++ b/interpreter/src/execution/values/list.rs
@@ -31,7 +31,7 @@ use crate::{
     values::iterators::{IterableObject, ValueIterator},
 };
 
-use super::{value_type::ValueType, ExpressionResult, Object, StaticTypeName, Value};
+use super::{value_type::ValueType, ExecutionResult, Object, StaticTypeName, Value};
 
 use std::{borrow::Cow, cmp::Ordering, collections::HashMap, sync::Arc};
 
@@ -51,8 +51,8 @@ impl List {
     pub fn from_ast(
         context: &ExecutionContext,
         ast_node: &AstNode<Vec<AstNode<Expression>>>,
-    ) -> ExpressionResult<Self> {
-        let values: ExpressionResult<Vec<Value>> = ast_node
+    ) -> ExecutionResult<Self> {
+        let values: ExecutionResult<Vec<Value>> = ast_node
             .node
             .par_iter()
             .map(|expression| execute_expression(context, expression))
@@ -87,8 +87,8 @@ impl List {
         &self,
         context: &ExecutionContext,
         operation_name: &'static str,
-        mut operation: impl FnMut(&Value) -> ExpressionResult<Value>,
-    ) -> ExpressionResult<Self> {
+        mut operation: impl FnMut(&Value) -> ExecutionResult<Value>,
+    ) -> ExecutionResult<Self> {
         let values: Vec<Value> = self
             .values
             .iter()
@@ -110,8 +110,8 @@ impl List {
         &self,
         context: &ExecutionContext,
         operation_name: &'static str,
-        operation: impl FnMut(&Value) -> ExpressionResult<Value>,
-    ) -> ExpressionResult<Value> {
+        operation: impl FnMut(&Value) -> ExecutionResult<Value>,
+    ) -> ExecutionResult<Value> {
         self.map_raw(context, operation_name, operation)
             .map(|value| value.into())
     }
@@ -145,16 +145,12 @@ impl Object for List {
         Ok(())
     }
 
-    fn eq(self, context: &ExecutionContext, rhs: Value) -> ExpressionResult<bool> {
+    fn eq(self, context: &ExecutionContext, rhs: Value) -> ExecutionResult<bool> {
         let rhs: &Self = rhs.downcast_for_binary_op_ref(context.stack_trace)?;
         Ok(self.values == rhs.values)
     }
 
-    fn get_attribute(
-        &self,
-        context: &ExecutionContext,
-        attribute: &str,
-    ) -> ExpressionResult<Value> {
+    fn get_attribute(&self, context: &ExecutionContext, attribute: &str) -> ExecutionResult<Value> {
         match attribute {
             "append" => Ok(BuiltinFunction::new::<methods::Append>().into()),
             "slice" => Ok(BuiltinFunction::new::<methods::Slice>().into()),
@@ -184,82 +180,82 @@ impl Object for List {
         }
     }
 
-    fn and(self, context: &ExecutionContext, rhs: Value) -> ExpressionResult<Value> {
+    fn and(self, context: &ExecutionContext, rhs: Value) -> ExecutionResult<Value> {
         self.map_operation(context, "and", move |value| {
             value.clone().and(context, rhs.clone())
         })
     }
-    fn or(self, context: &ExecutionContext, rhs: Value) -> ExpressionResult<Value> {
+    fn or(self, context: &ExecutionContext, rhs: Value) -> ExecutionResult<Value> {
         self.map_operation(context, "or", move |value| {
             value.clone().or(context, rhs.clone())
         })
     }
-    fn xor(self, context: &ExecutionContext, rhs: Value) -> ExpressionResult<Value> {
+    fn xor(self, context: &ExecutionContext, rhs: Value) -> ExecutionResult<Value> {
         self.map_operation(context, "xor", move |value| {
             value.clone().xor(context, rhs.clone())
         })
     }
-    fn bit_and(self, context: &ExecutionContext, rhs: Value) -> ExpressionResult<Value> {
+    fn bit_and(self, context: &ExecutionContext, rhs: Value) -> ExecutionResult<Value> {
         self.map_operation(context, "bit and", move |value| {
             value.clone().bit_and(context, rhs.clone())
         })
     }
-    fn bit_or(self, context: &ExecutionContext, rhs: Value) -> ExpressionResult<Value> {
+    fn bit_or(self, context: &ExecutionContext, rhs: Value) -> ExecutionResult<Value> {
         self.map_operation(context, "bit or", move |value| {
             value.clone().bit_or(context, rhs.clone())
         })
     }
-    fn bit_xor(self, context: &ExecutionContext, rhs: Value) -> ExpressionResult<Value> {
+    fn bit_xor(self, context: &ExecutionContext, rhs: Value) -> ExecutionResult<Value> {
         self.map_operation(context, "bit xor", move |value| {
             value.clone().bit_xor(context, rhs.clone())
         })
     }
-    fn addition(self, context: &ExecutionContext, rhs: Value) -> ExpressionResult<Value> {
+    fn addition(self, context: &ExecutionContext, rhs: Value) -> ExecutionResult<Value> {
         self.map_operation(context, "addition", move |value| {
             value.clone().addition(context, rhs.clone())
         })
     }
-    fn subtraction(self, context: &ExecutionContext, rhs: Value) -> ExpressionResult<Value> {
+    fn subtraction(self, context: &ExecutionContext, rhs: Value) -> ExecutionResult<Value> {
         self.map_operation(context, "subtraction", move |value| {
             value.clone().subtraction(context, rhs.clone())
         })
     }
-    fn multiply(self, context: &ExecutionContext, rhs: Value) -> ExpressionResult<Value> {
+    fn multiply(self, context: &ExecutionContext, rhs: Value) -> ExecutionResult<Value> {
         self.map_operation(context, "multiply", move |value| {
             value.clone().multiply(context, rhs.clone())
         })
     }
-    fn divide(self, context: &ExecutionContext, rhs: Value) -> ExpressionResult<Value> {
+    fn divide(self, context: &ExecutionContext, rhs: Value) -> ExecutionResult<Value> {
         self.map_operation(context, "divide", move |value| {
             value.clone().divide(context, rhs.clone())
         })
     }
-    fn exponent(self, context: &ExecutionContext, rhs: Value) -> ExpressionResult<Value> {
+    fn exponent(self, context: &ExecutionContext, rhs: Value) -> ExecutionResult<Value> {
         self.map_operation(context, "exponent", move |value| {
             value.clone().exponent(context, rhs.clone())
         })
     }
-    fn left_shift(self, context: &ExecutionContext, rhs: Value) -> ExpressionResult<Value> {
+    fn left_shift(self, context: &ExecutionContext, rhs: Value) -> ExecutionResult<Value> {
         self.map_operation(context, "left shift", move |value| {
             value.clone().left_shift(context, rhs.clone())
         })
     }
-    fn right_shift(self, context: &ExecutionContext, rhs: Value) -> ExpressionResult<Value> {
+    fn right_shift(self, context: &ExecutionContext, rhs: Value) -> ExecutionResult<Value> {
         self.map_operation(context, "right shift", move |value| {
             value.clone().right_shift(context, rhs.clone())
         })
     }
-    fn unary_plus(self, context: &ExecutionContext) -> ExpressionResult<Value> {
+    fn unary_plus(self, context: &ExecutionContext) -> ExecutionResult<Value> {
         self.map_operation(context, "unary plus", move |value| {
             value.clone().unary_plus(context)
         })
     }
-    fn unary_minus(self, context: &ExecutionContext) -> ExpressionResult<Value> {
+    fn unary_minus(self, context: &ExecutionContext) -> ExecutionResult<Value> {
         self.map_operation(context, "unary minus", move |value| {
             value.clone().unary_minus(context)
         })
     }
-    fn unary_not(self, context: &ExecutionContext) -> ExpressionResult<Value> {
+    fn unary_not(self, context: &ExecutionContext) -> ExecutionResult<Value> {
         self.map_operation(context, "unary not", move |value| {
             value.clone().unary_not(context)
         })
@@ -286,8 +282,8 @@ pub struct ListIterator {
 impl IterableObject for ListIterator {
     fn iterate<R>(
         &self,
-        callback: impl FnOnce(&mut dyn Iterator<Item = Value>) -> ExpressionResult<R>,
-    ) -> ExpressionResult<R> {
+        callback: impl FnOnce(&mut dyn Iterator<Item = Value>) -> ExecutionResult<R>,
+    ) -> ExecutionResult<R> {
         let mut iter = self.list.values.iter().cloned();
         callback(&mut iter)
     }
@@ -301,8 +297,8 @@ pub struct ListReverseIterator {
 impl IterableObject for ListReverseIterator {
     fn iterate<R>(
         &self,
-        callback: impl FnOnce(&mut dyn Iterator<Item = Value>) -> ExpressionResult<R>,
-    ) -> ExpressionResult<R> {
+        callback: impl FnOnce(&mut dyn Iterator<Item = Value>) -> ExecutionResult<R>,
+    ) -> ExecutionResult<R> {
         let mut iter = self.list.values.iter().rev().cloned();
         callback(&mut iter)
     }

--- a/interpreter/src/execution/values/manifold_mesh.rs
+++ b/interpreter/src/execution/values/manifold_mesh.rs
@@ -117,7 +117,7 @@ impl Object for ManifoldMesh3D {
     }
 
     fn multiply(mut self, context: &ExecutionContext, rhs: Value) -> ExecutionResult<Value> {
-        let input = rhs.downcast::<Zero3>(context.stack_trace)?;
+        let input = rhs.downcast::<Zero3>(context)?;
         let vector = input.raw_value();
         let manifold = Arc::make_mut(&mut self.0);
         manifold.scale(vector.x, vector.y, vector.z);
@@ -125,14 +125,14 @@ impl Object for ManifoldMesh3D {
     }
 
     fn bit_or(self, context: &ExecutionContext, rhs: Value) -> ExecutionResult<Value> {
-        let rhs: &Self = rhs.downcast_for_binary_op_ref(context.stack_trace)?;
+        let rhs: &Self = rhs.downcast_for_binary_op_ref(context)?;
         let manifold = compute_boolean(&self.0, &rhs.0, OpType::Add)
             .map_err(|error| error.to_error(context))?;
         Ok(Self(Arc::new(manifold)).into())
     }
 
     fn bit_xor(self, context: &ExecutionContext, rhs: Value) -> ExecutionResult<Value> {
-        let rhs: &Self = rhs.downcast_for_binary_op_ref(context.stack_trace)?;
+        let rhs: &Self = rhs.downcast_for_binary_op_ref(context)?;
 
         // To compute xor, get the intersectiona and then subtract it from the union of the two
         // shapes.
@@ -150,7 +150,7 @@ impl Object for ManifoldMesh3D {
     }
 
     fn bit_and(self, context: &ExecutionContext, rhs: Value) -> ExecutionResult<Value> {
-        let rhs: &Self = rhs.downcast_for_binary_op_ref(context.stack_trace)?;
+        let rhs: &Self = rhs.downcast_for_binary_op_ref(context)?;
         let manifold = compute_boolean(&self.0, &rhs.0, OpType::Intersect)
             .map_err(|error| error.to_error(context))?;
         Ok(Self(Arc::new(manifold)).into())
@@ -410,7 +410,7 @@ pub fn register_methods_and_functions(database: &mut BuiltinCallableDatabase) {
             } else {
                 let path = context.store.get_or_init_file(context, &(&this, &scale, "binary"), format!("{}.stl", name.0), |file| {
                     let mut file = BufWriter::new(file);
-                    let scale = *Float::new(1.0 / *scale.value).unwrap_not_nan(context.stack_trace)?;
+                    let scale = *Float::new(1.0 / *scale.value).unwrap_not_nan(context)?;
 
                     // file.write_all(&serialized).map_err(|error| IoError(error).to_error(context))?;
                     let mut trampoline = || -> std::io::Result<()> {

--- a/interpreter/src/execution/values/manifold_mesh.rs
+++ b/interpreter/src/execution/values/manifold_mesh.rs
@@ -92,10 +92,8 @@ impl Object for ManifoldMesh3D {
                 Ok(self.into())
             }
             ArethmeticInput::Manifold(rhs) => {
-                let manifold =
-                    compute_boolean(&self.0, &rhs.0, OpType::Add).map_err(|message| {
-                        GenericFailure(message.into()).to_error(context.stack_trace)
-                    })?;
+                let manifold = compute_boolean(&self.0, &rhs.0, OpType::Add)
+                    .map_err(|error| error.to_error(context.stack_trace))?;
                 Ok(Self(Arc::new(manifold)).into())
             }
         }
@@ -111,10 +109,8 @@ impl Object for ManifoldMesh3D {
                 Ok(self.into())
             }
             ArethmeticInput::Manifold(rhs) => {
-                let manifold =
-                    compute_boolean(&self.0, &rhs.0, OpType::Subtract).map_err(|message| {
-                        GenericFailure(message.into()).to_error(context.stack_trace)
-                    })?;
+                let manifold = compute_boolean(&self.0, &rhs.0, OpType::Subtract)
+                    .map_err(|error| error.to_error(context.stack_trace))?;
                 Ok(Self(Arc::new(manifold)).into())
             }
         }
@@ -131,7 +127,7 @@ impl Object for ManifoldMesh3D {
     fn bit_or(self, context: &ExecutionContext, rhs: Value) -> ExecutionResult<Value> {
         let rhs: &Self = rhs.downcast_for_binary_op_ref(context.stack_trace)?;
         let manifold = compute_boolean(&self.0, &rhs.0, OpType::Add)
-            .map_err(|message| GenericFailure(message.into()).to_error(context.stack_trace))?;
+            .map_err(|error| error.to_error(context.stack_trace))?;
         Ok(Self(Arc::new(manifold)).into())
     }
 
@@ -142,13 +138,13 @@ impl Object for ManifoldMesh3D {
         // shapes.
 
         let intersection = compute_boolean(&self.0, &rhs.0, OpType::Intersect)
-            .map_err(|message| GenericFailure(message.into()).to_error(context.stack_trace))?;
+            .map_err(|error| error.to_error(context.stack_trace))?;
 
         let union = compute_boolean(&self.0, &rhs.0, OpType::Add)
-            .map_err(|message| GenericFailure(message.into()).to_error(context.stack_trace))?;
+            .map_err(|error| error.to_error(context.stack_trace))?;
 
         let difference = compute_boolean(&union, &intersection, OpType::Subtract)
-            .map_err(|message| GenericFailure(message.into()).to_error(context.stack_trace))?;
+            .map_err(|error| error.to_error(context.stack_trace))?;
 
         Ok(Self(Arc::new(difference)).into())
     }
@@ -156,7 +152,7 @@ impl Object for ManifoldMesh3D {
     fn bit_and(self, context: &ExecutionContext, rhs: Value) -> ExecutionResult<Value> {
         let rhs: &Self = rhs.downcast_for_binary_op_ref(context.stack_trace)?;
         let manifold = compute_boolean(&self.0, &rhs.0, OpType::Intersect)
-            .map_err(|message| GenericFailure(message.into()).to_error(context.stack_trace))?;
+            .map_err(|error| error.to_error(context.stack_trace))?;
         Ok(Self(Arc::new(manifold)).into())
     }
 
@@ -279,7 +275,7 @@ pub fn register_methods_and_functions(database: &mut BuiltinCallableDatabase) {
             let radius = unpack_radius(context, radius, diameter)?;
 
             let manifold = generate_cone(apex.into(), center.into(), radius, divide.0 as usize)
-                .map_err(|error| GenericFailure(error.into()).to_error(context.stack_trace))?;
+                .map_err(|error| error.to_error(context.stack_trace))?;
             Ok(ManifoldMesh3D(Arc::new(manifold)))
         }
     );
@@ -292,7 +288,7 @@ pub fn register_methods_and_functions(database: &mut BuiltinCallableDatabase) {
             let size: Vector3 = size.into();
             let size = size.raw_value();
 
-            let mut manifold = generate_cube().map_err(|error| GenericFailure(error.into()).to_error(context.stack_trace))?;
+            let mut manifold = generate_cube().map_err(|error| error.to_error(context.stack_trace))?;
             manifold.scale(size.x, size.y, size.z);
 
             Ok(ManifoldMesh3D(Arc::new(manifold)))
@@ -311,7 +307,7 @@ pub fn register_methods_and_functions(database: &mut BuiltinCallableDatabase) {
             let radius = unpack_radius(context, radius, diameter)?;
 
             let manifold = generate_cylinder(radius, height.into(), sectors.0 as usize, stacks.0 as usize)
-                .map_err(|error| GenericFailure(error.into()).to_error(context.stack_trace))?;
+                .map_err(|error| error.to_error(context.stack_trace))?;
             Ok(ManifoldMesh3D(Arc::new(manifold)))
         }
     );
@@ -326,7 +322,7 @@ pub fn register_methods_and_functions(database: &mut BuiltinCallableDatabase) {
             let scale = unpack_radius(context, radius, diameter)?;
 
             let mut manifold = generate_icosphere(subdivions.0 as u32)
-                .map_err(|error| GenericFailure(error.into()).to_error(context.stack_trace))?;
+                .map_err(|error| error.to_error(context.stack_trace))?;
             manifold.scale(scale, scale, scale);
 
             Ok(ManifoldMesh3D(Arc::new(manifold)))
@@ -342,7 +338,7 @@ pub fn register_methods_and_functions(database: &mut BuiltinCallableDatabase) {
             sectors: UnsignedInteger
         ) -> ManifoldMesh3D {
             let manifold = generate_torus(major_radius.into(), minor_raidus.into(), rings.0 as usize, sectors.0 as usize)
-                .map_err(|error| GenericFailure(error.into()).to_error(context.stack_trace))?;
+                .map_err(|error| error.to_error(context.stack_trace))?;
             Ok(ManifoldMesh3D(Arc::new(manifold)))
         }
     );
@@ -358,7 +354,7 @@ pub fn register_methods_and_functions(database: &mut BuiltinCallableDatabase) {
             let scale = unpack_radius(context, radius, diameter)?;
 
             let mut manifold = generate_uv_sphere(sectors.0 as usize, stacks.0 as usize)
-                .map_err(|error| GenericFailure(error.into()).to_error(context.stack_trace))?;
+                .map_err(|error| error.to_error(context.stack_trace))?;
             manifold.scale(scale, scale, scale);
 
             Ok(ManifoldMesh3D(Arc::new(manifold)))

--- a/interpreter/src/execution/values/manifold_mesh.rs
+++ b/interpreter/src/execution/values/manifold_mesh.rs
@@ -27,7 +27,7 @@ use std::{
 use crate::{
     build_function, build_method,
     execution::{
-        errors::{ExecutionResult, GenericFailure, Raise},
+        errors::{ExecutionResult, Raise, StrError},
         store::IoError,
     },
     values::{
@@ -250,12 +250,12 @@ fn unpack_radius(
             let diameter: RawFloat = diameter.into();
             Ok(diameter / 2.0)
         }
-        (Some(_), Some(_)) => Err(GenericFailure(
-            "You must provide the radius or the diameter, not both".into(),
+        (Some(_), Some(_)) => Err(StrError(
+            "You must provide the radius or the diameter, not both",
         )
         .to_error(context.stack_trace)),
-        (None, None) => Err(GenericFailure(
-            "You must provide the radius or the diameter, neither were provided".into(),
+        (None, None) => Err(StrError(
+            "You must provide the radius or the diameter, neither were provided",
         )
         .to_error(context.stack_trace)),
     }
@@ -399,7 +399,7 @@ pub fn register_methods_and_functions(database: &mut BuiltinCallableDatabase) {
                 // This thing doesn't kick back IO errors, so we'll collect to an infaulable
                 // structure and then write that ourselves.
                 let mut serialized = Vec::new();
-                write_stl(&mut serialized, mesh.iter()).map_err(|_| GenericFailure("Failed to serialize STL file".into()).to_error(context.stack_trace))?;
+                write_stl(&mut serialized, mesh.iter()).map_err(|_| StrError("Failed to serialize STL file").to_error(context.stack_trace))?;
 
                 let path = context.store.get_or_init_file(context, &(&this, &scale, "ascii"), format!("{}.stl", name.0), |file| {
                     file.write_all(&serialized).map_err(|error| IoError(error).to_error(context.stack_trace))?;

--- a/interpreter/src/execution/values/manifold_mesh.rs
+++ b/interpreter/src/execution/values/manifold_mesh.rs
@@ -93,7 +93,7 @@ impl Object for ManifoldMesh3D {
             }
             ArethmeticInput::Manifold(rhs) => {
                 let manifold = compute_boolean(&self.0, &rhs.0, OpType::Add)
-                    .map_err(|error| error.to_error(context.stack_trace))?;
+                    .map_err(|error| error.to_error(context))?;
                 Ok(Self(Arc::new(manifold)).into())
             }
         }
@@ -110,7 +110,7 @@ impl Object for ManifoldMesh3D {
             }
             ArethmeticInput::Manifold(rhs) => {
                 let manifold = compute_boolean(&self.0, &rhs.0, OpType::Subtract)
-                    .map_err(|error| error.to_error(context.stack_trace))?;
+                    .map_err(|error| error.to_error(context))?;
                 Ok(Self(Arc::new(manifold)).into())
             }
         }
@@ -127,7 +127,7 @@ impl Object for ManifoldMesh3D {
     fn bit_or(self, context: &ExecutionContext, rhs: Value) -> ExecutionResult<Value> {
         let rhs: &Self = rhs.downcast_for_binary_op_ref(context.stack_trace)?;
         let manifold = compute_boolean(&self.0, &rhs.0, OpType::Add)
-            .map_err(|error| error.to_error(context.stack_trace))?;
+            .map_err(|error| error.to_error(context))?;
         Ok(Self(Arc::new(manifold)).into())
     }
 
@@ -138,13 +138,13 @@ impl Object for ManifoldMesh3D {
         // shapes.
 
         let intersection = compute_boolean(&self.0, &rhs.0, OpType::Intersect)
-            .map_err(|error| error.to_error(context.stack_trace))?;
+            .map_err(|error| error.to_error(context))?;
 
         let union = compute_boolean(&self.0, &rhs.0, OpType::Add)
-            .map_err(|error| error.to_error(context.stack_trace))?;
+            .map_err(|error| error.to_error(context))?;
 
         let difference = compute_boolean(&union, &intersection, OpType::Subtract)
-            .map_err(|error| error.to_error(context.stack_trace))?;
+            .map_err(|error| error.to_error(context))?;
 
         Ok(Self(Arc::new(difference)).into())
     }
@@ -152,7 +152,7 @@ impl Object for ManifoldMesh3D {
     fn bit_and(self, context: &ExecutionContext, rhs: Value) -> ExecutionResult<Value> {
         let rhs: &Self = rhs.downcast_for_binary_op_ref(context.stack_trace)?;
         let manifold = compute_boolean(&self.0, &rhs.0, OpType::Intersect)
-            .map_err(|error| error.to_error(context.stack_trace))?;
+            .map_err(|error| error.to_error(context))?;
         Ok(Self(Arc::new(manifold)).into())
     }
 
@@ -162,7 +162,7 @@ impl Object for ManifoldMesh3D {
             _ => Err(MissingAttributeError {
                 name: attribute.into(),
             }
-            .to_error(context.stack_trace)),
+            .to_error(context)),
         }
     }
 }
@@ -193,7 +193,7 @@ impl ManifoldMesh3D {
                 expected: "Vector2 or Vector3 of lengths, or another ManifoldMesh3D".into(),
                 got: value.get_type(context).name(),
             }
-            .to_error(context.stack_trace)),
+            .to_error(context)),
         }?;
 
         match value {
@@ -205,7 +205,7 @@ impl ManifoldMesh3D {
                         expected: "Vector2 or Vector3 of lengths, or another ManifoldMesh3D".into(),
                         got: vector.get_type(context).name(),
                     }
-                    .to_error(context.stack_trace))
+                    .to_error(context))
                 } else {
                     Ok(ArethmeticInput::Vector(vector))
                 }
@@ -250,14 +250,13 @@ fn unpack_radius(
             let diameter: RawFloat = diameter.into();
             Ok(diameter / 2.0)
         }
-        (Some(_), Some(_)) => Err(StrError(
-            "You must provide the radius or the diameter, not both",
-        )
-        .to_error(context.stack_trace)),
+        (Some(_), Some(_)) => {
+            Err(StrError("You must provide the radius or the diameter, not both").to_error(context))
+        }
         (None, None) => Err(StrError(
             "You must provide the radius or the diameter, neither were provided",
         )
-        .to_error(context.stack_trace)),
+        .to_error(context)),
     }
 }
 
@@ -275,7 +274,7 @@ pub fn register_methods_and_functions(database: &mut BuiltinCallableDatabase) {
             let radius = unpack_radius(context, radius, diameter)?;
 
             let manifold = generate_cone(apex.into(), center.into(), radius, divide.0 as usize)
-                .map_err(|error| error.to_error(context.stack_trace))?;
+                .map_err(|error| error.to_error(context))?;
             Ok(ManifoldMesh3D(Arc::new(manifold)))
         }
     );
@@ -288,7 +287,7 @@ pub fn register_methods_and_functions(database: &mut BuiltinCallableDatabase) {
             let size: Vector3 = size.into();
             let size = size.raw_value();
 
-            let mut manifold = generate_cube().map_err(|error| error.to_error(context.stack_trace))?;
+            let mut manifold = generate_cube().map_err(|error| error.to_error(context))?;
             manifold.scale(size.x, size.y, size.z);
 
             Ok(ManifoldMesh3D(Arc::new(manifold)))
@@ -307,7 +306,7 @@ pub fn register_methods_and_functions(database: &mut BuiltinCallableDatabase) {
             let radius = unpack_radius(context, radius, diameter)?;
 
             let manifold = generate_cylinder(radius, height.into(), sectors.0 as usize, stacks.0 as usize)
-                .map_err(|error| error.to_error(context.stack_trace))?;
+                .map_err(|error| error.to_error(context))?;
             Ok(ManifoldMesh3D(Arc::new(manifold)))
         }
     );
@@ -322,7 +321,7 @@ pub fn register_methods_and_functions(database: &mut BuiltinCallableDatabase) {
             let scale = unpack_radius(context, radius, diameter)?;
 
             let mut manifold = generate_icosphere(subdivions.0 as u32)
-                .map_err(|error| error.to_error(context.stack_trace))?;
+                .map_err(|error| error.to_error(context))?;
             manifold.scale(scale, scale, scale);
 
             Ok(ManifoldMesh3D(Arc::new(manifold)))
@@ -338,7 +337,7 @@ pub fn register_methods_and_functions(database: &mut BuiltinCallableDatabase) {
             sectors: UnsignedInteger
         ) -> ManifoldMesh3D {
             let manifold = generate_torus(major_radius.into(), minor_raidus.into(), rings.0 as usize, sectors.0 as usize)
-                .map_err(|error| error.to_error(context.stack_trace))?;
+                .map_err(|error| error.to_error(context))?;
             Ok(ManifoldMesh3D(Arc::new(manifold)))
         }
     );
@@ -354,7 +353,7 @@ pub fn register_methods_and_functions(database: &mut BuiltinCallableDatabase) {
             let scale = unpack_radius(context, radius, diameter)?;
 
             let mut manifold = generate_uv_sphere(sectors.0 as usize, stacks.0 as usize)
-                .map_err(|error| error.to_error(context.stack_trace))?;
+                .map_err(|error| error.to_error(context))?;
             manifold.scale(scale, scale, scale);
 
             Ok(ManifoldMesh3D(Arc::new(manifold)))
@@ -399,10 +398,10 @@ pub fn register_methods_and_functions(database: &mut BuiltinCallableDatabase) {
                 // This thing doesn't kick back IO errors, so we'll collect to an infaulable
                 // structure and then write that ourselves.
                 let mut serialized = Vec::new();
-                write_stl(&mut serialized, mesh.iter()).map_err(|_| StrError("Failed to serialize STL file").to_error(context.stack_trace))?;
+                write_stl(&mut serialized, mesh.iter()).map_err(|_| StrError("Failed to serialize STL file").to_error(context))?;
 
                 let path = context.store.get_or_init_file(context, &(&this, &scale, "ascii"), format!("{}.stl", name.0), |file| {
-                    file.write_all(&serialized).map_err(|error| IoError(error).to_error(context.stack_trace))?;
+                    file.write_all(&serialized).map_err(|error| IoError(error).to_error(context))?;
 
                     Ok(())
                 })?;
@@ -413,7 +412,7 @@ pub fn register_methods_and_functions(database: &mut BuiltinCallableDatabase) {
                     let mut file = BufWriter::new(file);
                     let scale = *Float::new(1.0 / *scale.value).unwrap_not_nan(context.stack_trace)?;
 
-                    // file.write_all(&serialized).map_err(|error| IoError(error).to_error(context.stack_trace))?;
+                    // file.write_all(&serialized).map_err(|error| IoError(error).to_error(context))?;
                     let mut trampoline = || -> std::io::Result<()> {
                         writeln!(file, "solid {}", name.0)?;
 
@@ -444,7 +443,7 @@ pub fn register_methods_and_functions(database: &mut BuiltinCallableDatabase) {
                         Ok(())
                     };
 
-                    trampoline().map_err(|error| IoError(error).to_error(context.stack_trace))?;
+                    trampoline().map_err(|error| IoError(error).to_error(context))?;
 
                     Ok(())
                 })?;

--- a/interpreter/src/execution/values/manifold_mesh.rs
+++ b/interpreter/src/execution/values/manifold_mesh.rs
@@ -369,83 +369,85 @@ pub fn register_methods_and_functions(database: &mut BuiltinCallableDatabase) {
             }.into(),
             ascii: Boolean = Boolean(false).into()
         ) -> File {
-            if !ascii.0 {
-                // Produce a binary STL
-                let mut mesh = Vec::new();
+            context.trace_scope(Some("Failed to write stl file".into()), context.stack_trace.bottom().clone(), |context| {
+                if !ascii.0 {
+                    // Produce a binary STL
+                    let mut mesh = Vec::new();
 
-                use stl_io::{Triangle, Vertex, write_stl};
+                    use stl_io::{Triangle, Vertex, write_stl};
 
-                for (normal, halfedge) in this.0.face_normals.iter().zip(this.0.hs.chunks(3)) {
-                    let p0 = this.0.ps[halfedge[0].tail];
-                    let p1 = this.0.ps[halfedge[1].tail];
-                    let p2 = this.0.ps[halfedge[2].tail];
+                    for (normal, halfedge) in this.0.face_normals.iter().zip(this.0.hs.chunks(3)) {
+                        let p0 = this.0.ps[halfedge[0].tail];
+                        let p1 = this.0.ps[halfedge[1].tail];
+                        let p2 = this.0.ps[halfedge[2].tail];
 
-                    let scale = 1.0 / *scale.value;
+                        let scale = 1.0 / *scale.value;
 
-                    let triangle = Triangle {
-                        normal: Vertex::new([(normal.x * scale) as f32, (normal.y * scale) as f32, (normal.z * scale) as f32]),
-                        vertices: [Vertex::new([(p0.x * scale) as f32, (p0.y * scale) as f32, (p0.z * scale) as f32]),
-                                   Vertex::new([(p1.x * scale) as f32, (p1.y * scale) as f32, (p1.z * scale) as f32]),
-                                   Vertex::new([(p2.x * scale) as f32, (p2.y * scale) as f32, (p2.z * scale) as f32])]
-                    };
+                        let triangle = Triangle {
+                            normal: Vertex::new([(normal.x * scale) as f32, (normal.y * scale) as f32, (normal.z * scale) as f32]),
+                            vertices: [Vertex::new([(p0.x * scale) as f32, (p0.y * scale) as f32, (p0.z * scale) as f32]),
+                                       Vertex::new([(p1.x * scale) as f32, (p1.y * scale) as f32, (p1.z * scale) as f32]),
+                                       Vertex::new([(p2.x * scale) as f32, (p2.y * scale) as f32, (p2.z * scale) as f32])]
+                        };
 
-                    mesh.push(triangle);
-                }
+                        mesh.push(triangle);
+                    }
 
-                // This thing doesn't kick back IO errors, so we'll collect to an infaulable
-                // structure and then write that ourselves.
-                let mut serialized = Vec::new();
-                write_stl(&mut serialized, mesh.iter()).map_err(|_| StrError("Failed to serialize STL file").to_error(context))?;
+                    // This thing doesn't kick back IO errors, so we'll collect to an infaulable
+                    // structure and then write that ourselves.
+                    let mut serialized = Vec::new();
+                    write_stl(&mut serialized, mesh.iter()).map_err(|_| StrError("Failed to serialize STL file").to_error(context))?;
 
-                let path = context.store.get_or_init_file(context, &(&this, &scale, "ascii"), format!("{}.stl", name.0), |file| {
-                    file.write_all(&serialized).map_err(|error| error.to_error(context))?;
-
-                    Ok(())
-                })?;
-
-                Ok(File { path: Arc::new(path) })
-            } else {
-                let path = context.store.get_or_init_file(context, &(&this, &scale, "binary"), format!("{}.stl", name.0), |file| {
-                    let mut file = BufWriter::new(file);
-                    let scale = *Float::new(1.0 / *scale.value).unwrap_not_nan(context)?;
-
-                    let mut trampoline = || -> std::io::Result<()> {
-                        writeln!(file, "solid {}", name.0)?;
-
-                        for (normal, halfedge) in this.0.face_normals.iter().zip(this.0.hs.chunks(3)) {
-                            let p0 = this.0.ps[halfedge[0].tail];
-                            let p1 = this.0.ps[halfedge[1].tail];
-                            let p2 = this.0.ps[halfedge[2].tail];
-
-                            writeln!(file, "\tfacet normal {} {} {}", normal.x, normal.y, normal.z)?;
-
-                            {
-                                writeln!(file, "\t\touter loop")?;
-
-                                {
-                                    writeln!(file, "\t\t\tvertex {} {} {}", p0.x * scale, p0.y * scale, p0.z * scale)?;
-                                    writeln!(file, "\t\t\tvertex {} {} {}", p1.x * scale, p1.y * scale, p1.z * scale)?;
-                                    writeln!(file, "\t\t\tvertex {} {} {}", p2.x * scale, p2.y * scale, p2.z * scale)?;
-                                }
-
-                                writeln!(file, "\t\tendloop")?;
-                            }
-
-                            writeln!(file, "\tendfacet")?;
-                        }
-
-                        writeln!(file, "endsolid {}", name.0)?;
+                    let path = context.store.get_or_init_file(context, &(&this, &scale, "ascii"), format!("{}.stl", name.0), |file| {
+                        file.write_all(&serialized).map_err(|error| error.to_error(context))?;
 
                         Ok(())
-                    };
+                    })?;
 
-                    trampoline().map_err(|error| error.to_error(context))?;
+                    Ok(File { path: Arc::new(path) })
+                } else {
+                    let path = context.store.get_or_init_file(context, &(&this, &scale, "binary"), format!("{}.stl", name.0), |file| {
+                        let mut file = BufWriter::new(file);
+                        let scale = *Float::new(1.0 / *scale.value).unwrap_not_nan(context)?;
 
-                    Ok(())
-                })?;
+                        let mut trampoline = || -> std::io::Result<()> {
+                            writeln!(file, "solid {}", name.0)?;
 
-                Ok(File { path: Arc::new(path) })
-            }
+                            for (normal, halfedge) in this.0.face_normals.iter().zip(this.0.hs.chunks(3)) {
+                                let p0 = this.0.ps[halfedge[0].tail];
+                                let p1 = this.0.ps[halfedge[1].tail];
+                                let p2 = this.0.ps[halfedge[2].tail];
+
+                                writeln!(file, "\tfacet normal {} {} {}", normal.x, normal.y, normal.z)?;
+
+                                {
+                                    writeln!(file, "\t\touter loop")?;
+
+                                    {
+                                        writeln!(file, "\t\t\tvertex {} {} {}", p0.x * scale, p0.y * scale, p0.z * scale)?;
+                                        writeln!(file, "\t\t\tvertex {} {} {}", p1.x * scale, p1.y * scale, p1.z * scale)?;
+                                        writeln!(file, "\t\t\tvertex {} {} {}", p2.x * scale, p2.y * scale, p2.z * scale)?;
+                                    }
+
+                                    writeln!(file, "\t\tendloop")?;
+                                }
+
+                                writeln!(file, "\tendfacet")?;
+                            }
+
+                            writeln!(file, "endsolid {}", name.0)?;
+
+                            Ok(())
+                        };
+
+                        trampoline().map_err(|error| error.to_error(context))?;
+
+                        Ok(())
+                    })?;
+
+                    Ok(File { path: Arc::new(path) })
+                }
+            })
         }
     );
 }

--- a/interpreter/src/execution/values/manifold_mesh.rs
+++ b/interpreter/src/execution/values/manifold_mesh.rs
@@ -26,10 +26,7 @@ use std::{
 
 use crate::{
     build_function, build_method,
-    execution::{
-        errors::{ExecutionResult, Raise, StrError},
-        store::IoError,
-    },
+    execution::errors::{ExecutionResult, Raise, StrError},
     values::{
         scalar::{Length, UnwrapNotNan},
         vector::{Length3, Zero3},
@@ -401,7 +398,7 @@ pub fn register_methods_and_functions(database: &mut BuiltinCallableDatabase) {
                 write_stl(&mut serialized, mesh.iter()).map_err(|_| StrError("Failed to serialize STL file").to_error(context))?;
 
                 let path = context.store.get_or_init_file(context, &(&this, &scale, "ascii"), format!("{}.stl", name.0), |file| {
-                    file.write_all(&serialized).map_err(|error| IoError(error).to_error(context))?;
+                    file.write_all(&serialized).map_err(|error| error.to_error(context))?;
 
                     Ok(())
                 })?;
@@ -412,7 +409,6 @@ pub fn register_methods_and_functions(database: &mut BuiltinCallableDatabase) {
                     let mut file = BufWriter::new(file);
                     let scale = *Float::new(1.0 / *scale.value).unwrap_not_nan(context)?;
 
-                    // file.write_all(&serialized).map_err(|error| IoError(error).to_error(context))?;
                     let mut trampoline = || -> std::io::Result<()> {
                         writeln!(file, "solid {}", name.0)?;
 
@@ -443,7 +439,7 @@ pub fn register_methods_and_functions(database: &mut BuiltinCallableDatabase) {
                         Ok(())
                     };
 
-                    trampoline().map_err(|error| IoError(error).to_error(context))?;
+                    trampoline().map_err(|error| error.to_error(context))?;
 
                     Ok(())
                 })?;

--- a/interpreter/src/execution/values/mod.rs
+++ b/interpreter/src/execution/values/mod.rs
@@ -234,7 +234,7 @@ pub trait Object: StaticTypeName + Sized + Eq + PartialEq + Clone {
         Err(MissingAttributeError {
             name: attribute.into(),
         }
-        .to_error(context.stack_trace))
+        .to_error(context))
     }
     fn call_scope_type(&self, _context: &ExecutionContext) -> ScopeType {
         ScopeType::Isolated
@@ -363,6 +363,7 @@ impl Value {
         T: StaticTypeName,
         Self: AsVariant<T>,
     {
+        let notice_me = 0; // TODO replace stack_trace with context.
         self.downcast_ref(stack_trace)
     }
 

--- a/interpreter/src/execution/values/mod.rs
+++ b/interpreter/src/execution/values/mod.rs
@@ -27,7 +27,7 @@ use crate::{
     values::{iterators::ValueIterator, manifold_mesh::ManifoldMesh3D},
 };
 
-use super::errors::{ErrorType, ExpressionResult, Raise as _};
+use super::errors::{ErrorType, ExecutionResult, Raise as _};
 
 mod void;
 pub use void::ValueNone;
@@ -147,7 +147,7 @@ impl UnsupportedOperationError {
         object: &O,
         stack_trace: &StackTrace,
         operation_name: &'static str,
-    ) -> ExpressionResult<R> {
+    ) -> ExecutionResult<R> {
         Err(Self {
             type_name: object.type_name(),
             operation_name,
@@ -185,56 +185,52 @@ pub trait Object: StaticTypeName + Sized + Eq + PartialEq + Clone {
         Self::static_type_name()
     }
 
-    fn and(self, context: &ExecutionContext, _rhs: Value) -> ExpressionResult<Value> {
+    fn and(self, context: &ExecutionContext, _rhs: Value) -> ExecutionResult<Value> {
         UnsupportedOperationError::raise(&self, context.stack_trace, "logical and")
     }
-    fn or(self, context: &ExecutionContext, _rhs: Value) -> ExpressionResult<Value> {
+    fn or(self, context: &ExecutionContext, _rhs: Value) -> ExecutionResult<Value> {
         UnsupportedOperationError::raise(&self, context.stack_trace, "logical or")
     }
-    fn xor(self, context: &ExecutionContext, _rhs: Value) -> ExpressionResult<Value> {
+    fn xor(self, context: &ExecutionContext, _rhs: Value) -> ExecutionResult<Value> {
         UnsupportedOperationError::raise(&self, context.stack_trace, "logical xor")
     }
-    fn bit_and(self, context: &ExecutionContext, _rhs: Value) -> ExpressionResult<Value> {
+    fn bit_and(self, context: &ExecutionContext, _rhs: Value) -> ExecutionResult<Value> {
         UnsupportedOperationError::raise(&self, context.stack_trace, "binary and")
     }
-    fn bit_or(self, context: &ExecutionContext, _rhs: Value) -> ExpressionResult<Value> {
+    fn bit_or(self, context: &ExecutionContext, _rhs: Value) -> ExecutionResult<Value> {
         UnsupportedOperationError::raise(&self, context.stack_trace, "binary or")
     }
-    fn bit_xor(self, context: &ExecutionContext, _rhs: Value) -> ExpressionResult<Value> {
+    fn bit_xor(self, context: &ExecutionContext, _rhs: Value) -> ExecutionResult<Value> {
         UnsupportedOperationError::raise(&self, context.stack_trace, "binary xor")
     }
-    fn cmp(self, context: &ExecutionContext, _rhs: Value) -> ExpressionResult<Ordering> {
+    fn cmp(self, context: &ExecutionContext, _rhs: Value) -> ExecutionResult<Ordering> {
         UnsupportedOperationError::raise(&self, context.stack_trace, "compare")
     }
-    fn eq(self, context: &ExecutionContext, rhs: Value) -> ExpressionResult<bool> {
+    fn eq(self, context: &ExecutionContext, rhs: Value) -> ExecutionResult<bool> {
         Ok(matches!(self.cmp(context, rhs)?, Ordering::Equal))
     }
-    fn addition(self, context: &ExecutionContext, _rhs: Value) -> ExpressionResult<Value> {
+    fn addition(self, context: &ExecutionContext, _rhs: Value) -> ExecutionResult<Value> {
         UnsupportedOperationError::raise(&self, context.stack_trace, "addition")
     }
-    fn subtraction(self, context: &ExecutionContext, _rhs: Value) -> ExpressionResult<Value> {
+    fn subtraction(self, context: &ExecutionContext, _rhs: Value) -> ExecutionResult<Value> {
         UnsupportedOperationError::raise(&self, context.stack_trace, "subtraction")
     }
-    fn multiply(self, context: &ExecutionContext, _rhs: Value) -> ExpressionResult<Value> {
+    fn multiply(self, context: &ExecutionContext, _rhs: Value) -> ExecutionResult<Value> {
         UnsupportedOperationError::raise(&self, context.stack_trace, "multiply")
     }
-    fn divide(self, context: &ExecutionContext, _rhs: Value) -> ExpressionResult<Value> {
+    fn divide(self, context: &ExecutionContext, _rhs: Value) -> ExecutionResult<Value> {
         UnsupportedOperationError::raise(&self, context.stack_trace, "divide")
     }
-    fn exponent(self, context: &ExecutionContext, _rhs: Value) -> ExpressionResult<Value> {
+    fn exponent(self, context: &ExecutionContext, _rhs: Value) -> ExecutionResult<Value> {
         UnsupportedOperationError::raise(&self, context.stack_trace, "exponent")
     }
-    fn left_shift(self, context: &ExecutionContext, _rhs: Value) -> ExpressionResult<Value> {
+    fn left_shift(self, context: &ExecutionContext, _rhs: Value) -> ExecutionResult<Value> {
         UnsupportedOperationError::raise(&self, context.stack_trace, "left shift")
     }
-    fn right_shift(self, context: &ExecutionContext, _rhs: Value) -> ExpressionResult<Value> {
+    fn right_shift(self, context: &ExecutionContext, _rhs: Value) -> ExecutionResult<Value> {
         UnsupportedOperationError::raise(&self, context.stack_trace, "right shift")
     }
-    fn get_attribute(
-        &self,
-        context: &ExecutionContext,
-        attribute: &str,
-    ) -> ExpressionResult<Value> {
+    fn get_attribute(&self, context: &ExecutionContext, attribute: &str) -> ExecutionResult<Value> {
         Err(MissingAttributeError {
             name: attribute.into(),
         }
@@ -243,26 +239,26 @@ pub trait Object: StaticTypeName + Sized + Eq + PartialEq + Clone {
     fn call_scope_type(&self, _context: &ExecutionContext) -> ScopeType {
         ScopeType::Isolated
     }
-    fn call(&self, context: &ExecutionContext, _argument: Dictionary) -> ExpressionResult<Value> {
+    fn call(&self, context: &ExecutionContext, _argument: Dictionary) -> ExecutionResult<Value> {
         UnsupportedOperationError::raise(self, context.stack_trace, "call")
     }
-    fn formula_call(&self, context: &ExecutionContext, _value: Value) -> ExpressionResult<Value> {
+    fn formula_call(&self, context: &ExecutionContext, _value: Value) -> ExecutionResult<Value> {
         UnsupportedOperationError::raise(self, context.stack_trace, "inverse call")
     }
     fn formula_inverse_call(
         &self,
         context: &ExecutionContext,
         _value: Value,
-    ) -> ExpressionResult<Value> {
+    ) -> ExecutionResult<Value> {
         UnsupportedOperationError::raise(self, context.stack_trace, "inverse call")
     }
-    fn unary_plus(self, context: &ExecutionContext) -> ExpressionResult<Value> {
+    fn unary_plus(self, context: &ExecutionContext) -> ExecutionResult<Value> {
         UnsupportedOperationError::raise(&self, context.stack_trace, "unary plus")
     }
-    fn unary_minus(self, context: &ExecutionContext) -> ExpressionResult<Value> {
+    fn unary_minus(self, context: &ExecutionContext) -> ExecutionResult<Value> {
         UnsupportedOperationError::raise(&self, context.stack_trace, "unary minus")
     }
-    fn unary_not(self, context: &ExecutionContext) -> ExpressionResult<Value> {
+    fn unary_not(self, context: &ExecutionContext) -> ExecutionResult<Value> {
         UnsupportedOperationError::raise(&self, context.stack_trace, "unary not")
     }
 
@@ -362,7 +358,7 @@ impl IntoVariant<Self> for Value {
 }
 
 impl Value {
-    pub fn downcast_for_binary_op_ref<T>(&self, stack_trace: &StackTrace) -> ExpressionResult<&T>
+    pub fn downcast_for_binary_op_ref<T>(&self, stack_trace: &StackTrace) -> ExecutionResult<&T>
     where
         T: StaticTypeName,
         Self: AsVariant<T>,
@@ -370,7 +366,7 @@ impl Value {
         self.downcast_ref(stack_trace)
     }
 
-    pub fn downcast_for_binary_op<T>(self, stack_trace: &StackTrace) -> ExpressionResult<T>
+    pub fn downcast_for_binary_op<T>(self, stack_trace: &StackTrace) -> ExecutionResult<T>
     where
         T: StaticTypeName,
         Self: IntoVariant<T>,
@@ -378,7 +374,7 @@ impl Value {
         self.downcast(stack_trace)
     }
 
-    pub fn downcast_ref<T>(&self, stack_trace: &StackTrace) -> ExpressionResult<&T>
+    pub fn downcast_ref<T>(&self, stack_trace: &StackTrace) -> ExecutionResult<&T>
     where
         T: StaticTypeName,
         Self: AsVariant<T>,
@@ -394,7 +390,7 @@ impl Value {
         }
     }
 
-    pub fn downcast<T>(self, stack_trace: &StackTrace) -> ExpressionResult<T>
+    pub fn downcast<T>(self, stack_trace: &StackTrace) -> ExecutionResult<T>
     where
         T: StaticTypeName,
         Self: IntoVariant<T>,
@@ -409,7 +405,7 @@ impl Value {
         }
     }
 
-    pub fn downcast_optional<T>(self, stack_trace: &StackTrace) -> ExpressionResult<Option<T>>
+    pub fn downcast_optional<T>(self, stack_trace: &StackTrace) -> ExecutionResult<Option<T>>
     where
         T: StaticTypeName,
         Self: IntoVariant<T>,

--- a/interpreter/src/execution/values/mod.rs
+++ b/interpreter/src/execution/values/mod.rs
@@ -23,7 +23,7 @@ use enum_downcast::{AsVariant, EnumDowncast, IntoVariant};
 use unwrap_enum::EnumAs;
 
 use crate::{
-    execution::{logging::StackTrace, stack::ScopeType, ExecutionContext},
+    execution::{stack::ScopeType, ExecutionContext},
     values::{iterators::ValueIterator, manifold_mesh::ManifoldMesh3D},
 };
 
@@ -145,14 +145,14 @@ impl Display for UnsupportedOperationError {
 impl UnsupportedOperationError {
     fn raise<O: Object + Sized, R>(
         object: &O,
-        stack_trace: &StackTrace,
+        context: &ExecutionContext,
         operation_name: &'static str,
     ) -> ExecutionResult<R> {
         Err(Self {
             type_name: object.type_name(),
             operation_name,
         }
-        .to_error(stack_trace))
+        .to_error(context))
     }
 }
 
@@ -186,49 +186,49 @@ pub trait Object: StaticTypeName + Sized + Eq + PartialEq + Clone {
     }
 
     fn and(self, context: &ExecutionContext, _rhs: Value) -> ExecutionResult<Value> {
-        UnsupportedOperationError::raise(&self, context.stack_trace, "logical and")
+        UnsupportedOperationError::raise(&self, context, "logical and")
     }
     fn or(self, context: &ExecutionContext, _rhs: Value) -> ExecutionResult<Value> {
-        UnsupportedOperationError::raise(&self, context.stack_trace, "logical or")
+        UnsupportedOperationError::raise(&self, context, "logical or")
     }
     fn xor(self, context: &ExecutionContext, _rhs: Value) -> ExecutionResult<Value> {
-        UnsupportedOperationError::raise(&self, context.stack_trace, "logical xor")
+        UnsupportedOperationError::raise(&self, context, "logical xor")
     }
     fn bit_and(self, context: &ExecutionContext, _rhs: Value) -> ExecutionResult<Value> {
-        UnsupportedOperationError::raise(&self, context.stack_trace, "binary and")
+        UnsupportedOperationError::raise(&self, context, "binary and")
     }
     fn bit_or(self, context: &ExecutionContext, _rhs: Value) -> ExecutionResult<Value> {
-        UnsupportedOperationError::raise(&self, context.stack_trace, "binary or")
+        UnsupportedOperationError::raise(&self, context, "binary or")
     }
     fn bit_xor(self, context: &ExecutionContext, _rhs: Value) -> ExecutionResult<Value> {
-        UnsupportedOperationError::raise(&self, context.stack_trace, "binary xor")
+        UnsupportedOperationError::raise(&self, context, "binary xor")
     }
     fn cmp(self, context: &ExecutionContext, _rhs: Value) -> ExecutionResult<Ordering> {
-        UnsupportedOperationError::raise(&self, context.stack_trace, "compare")
+        UnsupportedOperationError::raise(&self, context, "compare")
     }
     fn eq(self, context: &ExecutionContext, rhs: Value) -> ExecutionResult<bool> {
         Ok(matches!(self.cmp(context, rhs)?, Ordering::Equal))
     }
     fn addition(self, context: &ExecutionContext, _rhs: Value) -> ExecutionResult<Value> {
-        UnsupportedOperationError::raise(&self, context.stack_trace, "addition")
+        UnsupportedOperationError::raise(&self, context, "addition")
     }
     fn subtraction(self, context: &ExecutionContext, _rhs: Value) -> ExecutionResult<Value> {
-        UnsupportedOperationError::raise(&self, context.stack_trace, "subtraction")
+        UnsupportedOperationError::raise(&self, context, "subtraction")
     }
     fn multiply(self, context: &ExecutionContext, _rhs: Value) -> ExecutionResult<Value> {
-        UnsupportedOperationError::raise(&self, context.stack_trace, "multiply")
+        UnsupportedOperationError::raise(&self, context, "multiply")
     }
     fn divide(self, context: &ExecutionContext, _rhs: Value) -> ExecutionResult<Value> {
-        UnsupportedOperationError::raise(&self, context.stack_trace, "divide")
+        UnsupportedOperationError::raise(&self, context, "divide")
     }
     fn exponent(self, context: &ExecutionContext, _rhs: Value) -> ExecutionResult<Value> {
-        UnsupportedOperationError::raise(&self, context.stack_trace, "exponent")
+        UnsupportedOperationError::raise(&self, context, "exponent")
     }
     fn left_shift(self, context: &ExecutionContext, _rhs: Value) -> ExecutionResult<Value> {
-        UnsupportedOperationError::raise(&self, context.stack_trace, "left shift")
+        UnsupportedOperationError::raise(&self, context, "left shift")
     }
     fn right_shift(self, context: &ExecutionContext, _rhs: Value) -> ExecutionResult<Value> {
-        UnsupportedOperationError::raise(&self, context.stack_trace, "right shift")
+        UnsupportedOperationError::raise(&self, context, "right shift")
     }
     fn get_attribute(&self, context: &ExecutionContext, attribute: &str) -> ExecutionResult<Value> {
         Err(MissingAttributeError {
@@ -240,26 +240,26 @@ pub trait Object: StaticTypeName + Sized + Eq + PartialEq + Clone {
         ScopeType::Isolated
     }
     fn call(&self, context: &ExecutionContext, _argument: Dictionary) -> ExecutionResult<Value> {
-        UnsupportedOperationError::raise(self, context.stack_trace, "call")
+        UnsupportedOperationError::raise(self, context, "call")
     }
     fn formula_call(&self, context: &ExecutionContext, _value: Value) -> ExecutionResult<Value> {
-        UnsupportedOperationError::raise(self, context.stack_trace, "inverse call")
+        UnsupportedOperationError::raise(self, context, "inverse call")
     }
     fn formula_inverse_call(
         &self,
         context: &ExecutionContext,
         _value: Value,
     ) -> ExecutionResult<Value> {
-        UnsupportedOperationError::raise(self, context.stack_trace, "inverse call")
+        UnsupportedOperationError::raise(self, context, "inverse call")
     }
     fn unary_plus(self, context: &ExecutionContext) -> ExecutionResult<Value> {
-        UnsupportedOperationError::raise(&self, context.stack_trace, "unary plus")
+        UnsupportedOperationError::raise(&self, context, "unary plus")
     }
     fn unary_minus(self, context: &ExecutionContext) -> ExecutionResult<Value> {
-        UnsupportedOperationError::raise(&self, context.stack_trace, "unary minus")
+        UnsupportedOperationError::raise(&self, context, "unary minus")
     }
     fn unary_not(self, context: &ExecutionContext) -> ExecutionResult<Value> {
-        UnsupportedOperationError::raise(&self, context.stack_trace, "unary not")
+        UnsupportedOperationError::raise(&self, context, "unary not")
     }
 
     // fn export(
@@ -358,24 +358,24 @@ impl IntoVariant<Self> for Value {
 }
 
 impl Value {
-    pub fn downcast_for_binary_op_ref<T>(&self, stack_trace: &StackTrace) -> ExecutionResult<&T>
+    pub fn downcast_for_binary_op_ref<T>(&self, context: &ExecutionContext) -> ExecutionResult<&T>
     where
         T: StaticTypeName,
         Self: AsVariant<T>,
     {
         let notice_me = 0; // TODO replace stack_trace with context.
-        self.downcast_ref(stack_trace)
+        self.downcast_ref(context)
     }
 
-    pub fn downcast_for_binary_op<T>(self, stack_trace: &StackTrace) -> ExecutionResult<T>
+    pub fn downcast_for_binary_op<T>(self, context: &ExecutionContext) -> ExecutionResult<T>
     where
         T: StaticTypeName,
         Self: IntoVariant<T>,
     {
-        self.downcast(stack_trace)
+        self.downcast(context)
     }
 
-    pub fn downcast_ref<T>(&self, stack_trace: &StackTrace) -> ExecutionResult<&T>
+    pub fn downcast_ref<T>(&self, context: &ExecutionContext) -> ExecutionResult<&T>
     where
         T: StaticTypeName,
         Self: AsVariant<T>,
@@ -387,11 +387,11 @@ impl Value {
                 expected: T::static_type_name(),
                 got: self.type_name(),
             }
-            .to_error(stack_trace))
+            .to_error(context))
         }
     }
 
-    pub fn downcast<T>(self, stack_trace: &StackTrace) -> ExecutionResult<T>
+    pub fn downcast<T>(self, context: &ExecutionContext) -> ExecutionResult<T>
     where
         T: StaticTypeName,
         Self: IntoVariant<T>,
@@ -402,18 +402,18 @@ impl Value {
                 expected: T::static_type_name(),
                 got: original.type_name(),
             }
-            .to_error(stack_trace)),
+            .to_error(context)),
         }
     }
 
-    pub fn downcast_optional<T>(self, stack_trace: &StackTrace) -> ExecutionResult<Option<T>>
+    pub fn downcast_optional<T>(self, context: &ExecutionContext) -> ExecutionResult<Option<T>>
     where
         T: StaticTypeName,
         Self: IntoVariant<T>,
     {
         match self {
             Self::ValueNone(_) => Ok(None),
-            this => Ok(Some(this.downcast_for_binary_op::<T>(stack_trace)?)),
+            this => Ok(Some(this.downcast_for_binary_op::<T>(context)?)),
         }
     }
 }

--- a/interpreter/src/execution/values/mod.rs
+++ b/interpreter/src/execution/values/mod.rs
@@ -27,7 +27,7 @@ use crate::{
     values::{iterators::ValueIterator, manifold_mesh::ManifoldMesh3D},
 };
 
-use super::errors::{ErrorType, ExecutionResult, Raise as _};
+use super::errors::{ExecutionResult, Raise as _};
 
 mod void;
 pub use void::ValueNone;
@@ -130,7 +130,7 @@ struct UnsupportedOperationError {
     pub operation_name: &'static str,
 }
 
-impl ErrorType for UnsupportedOperationError {}
+impl std::error::Error for UnsupportedOperationError {}
 
 impl Display for UnsupportedOperationError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -161,7 +161,7 @@ struct MissingAttributeError {
     pub name: String,
 }
 
-impl ErrorType for MissingAttributeError {}
+impl std::error::Error for MissingAttributeError {}
 
 impl Display for MissingAttributeError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -313,7 +313,7 @@ pub struct DowncastError {
     pub got: Cow<'static, str>,
 }
 
-impl ErrorType for DowncastError {}
+impl std::error::Error for DowncastError {}
 
 impl Display for DowncastError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -327,7 +327,7 @@ pub struct DowncastForBinaryOpError {
     pub got: Cow<'static, str>,
 }
 
-impl ErrorType for DowncastForBinaryOpError {}
+impl std::error::Error for DowncastForBinaryOpError {}
 
 impl Display for DowncastForBinaryOpError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/interpreter/src/execution/values/mod.rs
+++ b/interpreter/src/execution/values/mod.rs
@@ -363,7 +363,6 @@ impl Value {
         T: StaticTypeName,
         Self: AsVariant<T>,
     {
-        let notice_me = 0; // TODO replace stack_trace with context.
         self.downcast_ref(context)
     }
 

--- a/interpreter/src/execution/values/scalar.rs
+++ b/interpreter/src/execution/values/scalar.rs
@@ -185,7 +185,7 @@ impl Object for Scalar {
                 expected: ValueType::Scalar(Some(Dimension::zero())).name(),
                 got: rhs.get_type(context).name(),
             }
-            .to_error(context.stack_trace))
+            .to_error(context))
         }
     }
     fn unary_plus(self, _context: &ExecutionContext) -> ExecutionResult<Value> {
@@ -207,7 +207,7 @@ impl Object for Scalar {
                 expected: self.type_name(),
                 got: rhs.type_name(),
             }
-            .to_error(context.stack_trace))
+            .to_error(context))
         }
     }
 
@@ -254,7 +254,7 @@ impl Object for Scalar {
             _ => Err(MissingAttributeError {
                 name: attribute.into(),
             }
-            .to_error(context.stack_trace)),
+            .to_error(context)),
         }
     }
 
@@ -384,7 +384,7 @@ pub fn register_methods(database: &mut BuiltinCallableDatabase) {
                 Ok(values::SignedInteger::from(*this.value as i64))
             } else {
                 Err(StrError("Only zero dimensional scalars can be converted into an integer")
-                    .to_error(context.stack_trace))
+                    .to_error(context))
             }
         }
     );
@@ -399,11 +399,11 @@ pub fn register_methods(database: &mut BuiltinCallableDatabase) {
                     Ok(values::UnsignedInteger::from(*this.value as u64))
                 } else {
                     Err(StrError("Negative values cannot be converted to signed integers")
-                        .to_error(context.stack_trace))
+                        .to_error(context))
                 }
             } else {
                 Err(StrError("Only zero dimensional scalars can be converted into an integer")
-                    .to_error(context.stack_trace))
+                    .to_error(context))
             }
         }
     );

--- a/interpreter/src/execution/values/scalar.rs
+++ b/interpreter/src/execution/values/scalar.rs
@@ -22,7 +22,7 @@ use common_data_types::{Dimension, Float, FloatIsNan};
 use crate::{
     build_method,
     execution::{
-        errors::{ExecutionResult, GenericFailure, Raise},
+        errors::{ExecutionResult, Raise, StrError},
         logging::{LogLevel, LogMessage, StackTrace},
         values::{
             self, closure::BuiltinCallableDatabase, string::formatting::Style, Boolean,
@@ -44,10 +44,9 @@ impl UnwrapNotNan for std::result::Result<Float, FloatIsNan> {
     fn unwrap_not_nan(self, stack_trace: &StackTrace) -> ExecutionResult<Float> {
         match self {
             Ok(number) => Ok(number),
-            Err(_float_is_nan) => Err(GenericFailure(
-                "Result of arithmetic operation is NaN".into(),
-            )
-            .to_error(stack_trace)),
+            Err(_float_is_nan) => {
+                Err(StrError("Result of arithmetic operation is NaN").to_error(stack_trace))
+            }
         }
     }
 }
@@ -299,7 +298,7 @@ impl Scalar {
         if self.dimension.is_zero_dimension() {
             Ok(())
         } else {
-            Err(GenericFailure("Inverse trigonometric functions can only be used with zero dimensional types (Angles, Ratios)".into()).to_error(stack_trace))
+            Err(StrError("Inverse trigonometric functions can only be used with zero dimensional types (Angles, Ratios)").to_error(stack_trace))
         }
     }
 
@@ -308,7 +307,7 @@ impl Scalar {
             Ok(())
         } else {
             Err(
-                GenericFailure("Trigonometric functions can only be used with angles".into())
+                StrError("Trigonometric functions can only be used with angles")
                     .to_error(stack_trace),
             )
         }
@@ -384,7 +383,7 @@ pub fn register_methods(database: &mut BuiltinCallableDatabase) {
             if this.dimension.is_zero_dimension() {
                 Ok(values::SignedInteger::from(*this.value as i64))
             } else {
-                Err(GenericFailure("Only zero dimensional scalars can be converted into an integer".into())
+                Err(StrError("Only zero dimensional scalars can be converted into an integer")
                     .to_error(context.stack_trace))
             }
         }
@@ -399,11 +398,11 @@ pub fn register_methods(database: &mut BuiltinCallableDatabase) {
                 if *this.value >= 0.0 {
                     Ok(values::UnsignedInteger::from(*this.value as u64))
                 } else {
-                    Err(GenericFailure("Negative values cannot be converted to signed integers".into())
+                    Err(StrError("Negative values cannot be converted to signed integers")
                         .to_error(context.stack_trace))
                 }
             } else {
-                Err(GenericFailure("Only zero dimensional scalars can be converted into an integer".into())
+                Err(StrError("Only zero dimensional scalars can be converted into an integer")
                     .to_error(context.stack_trace))
             }
         }

--- a/interpreter/src/execution/values/scalar.rs
+++ b/interpreter/src/execution/values/scalar.rs
@@ -18,6 +18,7 @@
 use std::{borrow::Cow, cmp::Ordering, f64::consts::PI};
 
 use common_data_types::{Dimension, Float, FloatIsNan};
+use thiserror::Error;
 
 use crate::{
     build_method,
@@ -44,10 +45,19 @@ impl UnwrapNotNan for std::result::Result<Float, FloatIsNan> {
     fn unwrap_not_nan(self, context: &ExecutionContext) -> ExecutionResult<Float> {
         match self {
             Ok(number) => Ok(number),
-            Err(_float_is_nan) => {
-                Err(StrError("Result of arithmetic operation is NaN").to_error(context))
-            }
+            Err(_float_is_nan) => Err(ResultIsNan.to_error(context)),
         }
+    }
+}
+
+#[derive(Debug, Eq, PartialEq)]
+pub struct ResultIsNan;
+
+impl std::error::Error for ResultIsNan {}
+
+impl std::fmt::Display for ResultIsNan {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Result of operation is NaN")
     }
 }
 
@@ -376,6 +386,15 @@ mod methods {
     pub struct Tanh;
 }
 
+#[derive(Debug, Error)]
+pub enum ScalarToInteger {
+    #[error("Only zero dimensional scalars can be converted into an integer")]
+    NonZeroDimensionToInteger,
+
+    #[error("Negative values cannot be converted to unsigned integers")]
+    NegativeToUnsignedInteger,
+}
+
 pub fn register_methods(database: &mut BuiltinCallableDatabase) {
     build_method!(
         database,
@@ -386,7 +405,7 @@ pub fn register_methods(database: &mut BuiltinCallableDatabase) {
             if this.dimension.is_zero_dimension() {
                 Ok(values::SignedInteger::from(*this.value as i64))
             } else {
-                Err(StrError("Only zero dimensional scalars can be converted into an integer")
+                Err(ScalarToInteger::NonZeroDimensionToInteger
                     .to_error(context))
             }
         }
@@ -401,11 +420,11 @@ pub fn register_methods(database: &mut BuiltinCallableDatabase) {
                 if *this.value >= 0.0 {
                     Ok(values::UnsignedInteger::from(*this.value as u64))
                 } else {
-                    Err(StrError("Negative values cannot be converted to signed integers")
+                    Err(ScalarToInteger::NegativeToUnsignedInteger
                         .to_error(context))
                 }
             } else {
-                Err(StrError("Only zero dimensional scalars can be converted into an integer")
+                Err(ScalarToInteger::NonZeroDimensionToInteger
                     .to_error(context))
             }
         }
@@ -1026,7 +1045,10 @@ mod test {
         let product = test_run("(100m / 1m)::to_signed_integer() == 100i").unwrap();
         assert_eq!(product, Boolean(true).into());
 
-        test_run("100m::to_signed_integer()").unwrap_err();
+        let error = test_run("100m::to_signed_integer()").unwrap_err();
+        let error = error.ty.as_any();
+        let error: &ScalarToInteger = error.downcast_ref().unwrap();
+        assert!(matches!(error, ScalarToInteger::NonZeroDimensionToInteger));
     }
 
     #[test]
@@ -1037,8 +1059,15 @@ mod test {
         let product = test_run("(100m / 1m)::to_unsigned_integer() == 100u").unwrap();
         assert_eq!(product, Boolean(true).into());
 
-        test_run("(-100)::to_unsigned_integer()").unwrap_err();
-        test_run("100m::to_unsigned_integer()").unwrap_err();
+        let error = test_run("(-100)::to_unsigned_integer()").unwrap_err();
+        let error = error.ty.as_any();
+        let error: &ScalarToInteger = error.downcast_ref().unwrap();
+        assert!(matches!(error, ScalarToInteger::NegativeToUnsignedInteger));
+
+        let error = test_run("100m::to_unsigned_integer()").unwrap_err();
+        let error = error.ty.as_any();
+        let error: &ScalarToInteger = error.downcast_ref().unwrap();
+        assert!(matches!(error, ScalarToInteger::NonZeroDimensionToInteger));
     }
 
     #[test]

--- a/interpreter/src/execution/values/string/formatting.rs
+++ b/interpreter/src/execution/values/string/formatting.rs
@@ -31,7 +31,7 @@ use nom::{
 };
 
 use crate::execution::{
-    errors::{ExecutionResult, GenericFailure, Raise},
+    errors::{ExecutionResult, Raise, StringError},
     logging::{LocatedStr, StackTrace},
     values::{Dictionary, Object, UnsignedInteger},
     ExecutionContext,
@@ -209,20 +209,15 @@ impl Format {
                         if precision <= u8::MAX as u64 {
                             Ok(Some(precision as u8))
                         } else {
-                            Err(GenericFailure(
-                                format!(
-                                    "Precision of {precision} is not in the valid range of 0 to {}",
-                                    u8::MAX
-                                )
-                                .into(),
-                            )
+                            Err(StringError(format!(
+                                "Precision of {precision} is not in the valid range of 0 to {}",
+                                u8::MAX
+                            ))
                             .to_error(context.stack_trace))
                         }
                     } else {
-                        Err(
-                            GenericFailure(format!("Could not find argument `{name}`").into())
-                                .to_error(context.stack_trace),
-                        )
+                        Err(StringError(format!("Could not find argument `{name}`"))
+                            .to_error(context.stack_trace))
                     }
                 }
             }
@@ -251,14 +246,12 @@ impl Format {
                         argument
                             .format(context, f, *style, precision)
                             .map_err(|error| {
-                                GenericFailure(format!("Error while formatting: {error:?}").into())
+                                StringError(format!("Error while formatting: {error:?}"))
                                     .to_error(context.stack_trace)
                             })?;
                     } else {
-                        return Err(GenericFailure(
-                            format!("Could not find argument `{name}`").into(),
-                        )
-                        .to_error(context.stack_trace));
+                        return Err(StringError(format!("Could not find argument `{name}`"))
+                            .to_error(context.stack_trace));
                     }
                 }
             }
@@ -284,8 +277,7 @@ impl<R> UnwrapFormattingResult<R> for std::result::Result<R, std::fmt::Error> {
         match self {
             Ok(result) => Ok(result),
             Err(error) => {
-                Err(GenericFailure(format!("Failed to format: {error}",).into())
-                    .to_error(stack_trace))
+                Err(StringError(format!("Failed to format: {error}")).to_error(stack_trace))
             }
         }
     }

--- a/interpreter/src/execution/values/string/formatting.rs
+++ b/interpreter/src/execution/values/string/formatting.rs
@@ -31,7 +31,7 @@ use nom::{
 };
 
 use crate::execution::{
-    errors::{ExpressionResult, GenericFailure, Raise},
+    errors::{ExecutionResult, GenericFailure, Raise},
     logging::{LocatedStr, StackTrace},
     values::{Dictionary, Object, UnsignedInteger},
     ExecutionContext,
@@ -184,12 +184,12 @@ impl Format {
         context: &ExecutionContext,
         f: &mut dyn Write,
         arguments: Dictionary,
-    ) -> ExpressionResult<()> {
+    ) -> ExecutionResult<()> {
         fn get_precision(
             context: &ExecutionContext,
             precision: &Precision,
             arguments: &Dictionary,
-        ) -> ExpressionResult<Option<u8>> {
+        ) -> ExecutionResult<Option<u8>> {
             match precision {
                 Precision::Default => Ok(None),
                 Precision::Inline(precision) => Ok(Some(*precision)),
@@ -276,11 +276,11 @@ fn number(input: &str) -> VResult<&str, u8> {
 }
 
 pub trait UnwrapFormattingResult<R> {
-    fn unwrap_formatting_result(self, stack_trace: &StackTrace) -> ExpressionResult<R>;
+    fn unwrap_formatting_result(self, stack_trace: &StackTrace) -> ExecutionResult<R>;
 }
 
 impl<R> UnwrapFormattingResult<R> for std::result::Result<R, std::fmt::Error> {
-    fn unwrap_formatting_result(self, stack_trace: &StackTrace) -> ExpressionResult<R> {
+    fn unwrap_formatting_result(self, stack_trace: &StackTrace) -> ExecutionResult<R> {
         match self {
             Ok(result) => Ok(result),
             Err(error) => {

--- a/interpreter/src/execution/values/string/formatting.rs
+++ b/interpreter/src/execution/values/string/formatting.rs
@@ -213,11 +213,11 @@ impl Format {
                                 "Precision of {precision} is not in the valid range of 0 to {}",
                                 u8::MAX
                             ))
-                            .to_error(context.stack_trace))
+                            .to_error(context))
                         }
                     } else {
                         Err(StringError(format!("Could not find argument `{name}`"))
-                            .to_error(context.stack_trace))
+                            .to_error(context))
                     }
                 }
             }
@@ -247,11 +247,11 @@ impl Format {
                             .format(context, f, *style, precision)
                             .map_err(|error| {
                                 StringError(format!("Error while formatting: {error:?}"))
-                                    .to_error(context.stack_trace)
+                                    .to_error(context)
                             })?;
                     } else {
                         return Err(StringError(format!("Could not find argument `{name}`"))
-                            .to_error(context.stack_trace));
+                            .to_error(context));
                     }
                 }
             }

--- a/interpreter/src/execution/values/string/formatting.rs
+++ b/interpreter/src/execution/values/string/formatting.rs
@@ -221,41 +221,46 @@ impl Format {
             }
         }
 
-        for component in self.components.iter() {
-            match component {
-                Component::Litteral(text) => {
-                    write!(f, "{}", text).unwrap_formatting_result(context)?
-                }
-                Component::Parameter(Parameter {
-                    name,
-                    style,
-                    precision,
-                }) => {
-                    let precision = get_precision(context, precision, &arguments)?;
+        context.trace_scope(
+            Some("Failed to format string".into()),
+            context.stack_trace.bottom().clone(),
+            |context| {
+                for component in self.components.iter() {
+                    match component {
+                        Component::Litteral(text) => {
+                            write!(f, "{}", text).map_err(|error| error.to_error(context))?;
+                        }
+                        Component::Parameter(Parameter {
+                            name,
+                            style,
+                            precision,
+                        }) => {
+                            let precision = get_precision(context, precision, &arguments)?;
 
-                    if let Some(argument) = arguments.get(name.as_str()).or_else(|| {
-                        context
-                            .get_variable(LocatedStr {
-                                location: context.stack_trace.bottom().clone(),
-                                string: name.as_str(),
-                            })
-                            .ok()
-                    }) {
-                        argument
-                            .format(context, f, *style, precision)
-                            .map_err(|error| {
-                                StringError(format!("Error while formatting: {error:?}"))
-                                    .to_error(context)
-                            })?;
-                    } else {
-                        return Err(StringError(format!("Could not find argument `{name}`"))
-                            .to_error(context));
+                            if let Some(argument) = arguments.get(name.as_str()).or_else(|| {
+                                context
+                                    .get_variable(LocatedStr {
+                                        location: context.stack_trace.bottom().clone(),
+                                        string: name.as_str(),
+                                    })
+                                    .ok()
+                            }) {
+                                argument
+                                    .format(context, f, *style, precision)
+                                    .map_err(|error| error.to_error(context))?;
+                            } else {
+                                return Err(StringError(format!(
+                                    "Could not find argument `{name}`"
+                                ))
+                                .to_error(context));
+                            }
+                        }
                     }
                 }
-            }
-        }
 
-        Ok(())
+                Ok(())
+            },
+        )
     }
 }
 
@@ -264,19 +269,6 @@ fn number(input: &str) -> VResult<&str, u8> {
         digits.parse::<u8>().unwrap()
     })
     .parse(input)
-}
-
-pub trait UnwrapFormattingResult<R> {
-    fn unwrap_formatting_result(self, context: &ExecutionContext) -> ExecutionResult<R>;
-}
-
-impl<R> UnwrapFormattingResult<R> for std::result::Result<R, std::fmt::Error> {
-    fn unwrap_formatting_result(self, context: &ExecutionContext) -> ExecutionResult<R> {
-        match self {
-            Ok(result) => Ok(result),
-            Err(error) => Err(StringError(format!("Failed to format: {error}")).to_error(context)),
-        }
-    }
 }
 
 #[cfg(test)]

--- a/interpreter/src/execution/values/string/mod.rs
+++ b/interpreter/src/execution/values/string/mod.rs
@@ -38,7 +38,7 @@ use crate::{
     values::iterators::{IterableObject, ValueIterator},
 };
 
-use super::{value_type::ValueType, ExpressionResult, Object, StaticTypeName, Value};
+use super::{value_type::ValueType, ExecutionResult, Object, StaticTypeName, Value};
 
 use std::{borrow::Cow, collections::HashMap, sync::Arc};
 
@@ -78,16 +78,12 @@ impl Object for IString {
         write!(f, "{}", self.0)
     }
 
-    fn eq(self, context: &ExecutionContext, rhs: Value) -> ExpressionResult<bool> {
+    fn eq(self, context: &ExecutionContext, rhs: Value) -> ExecutionResult<bool> {
         let rhs: &Self = rhs.downcast_for_binary_op_ref(context.stack_trace)?;
         Ok(self.0 == rhs.0)
     }
 
-    fn get_attribute(
-        &self,
-        context: &ExecutionContext,
-        attribute: &str,
-    ) -> ExpressionResult<Value> {
+    fn get_attribute(&self, context: &ExecutionContext, attribute: &str) -> ExecutionResult<Value> {
         match attribute {
             "format" => Ok(BuiltinFunction::new::<methods::Format>().into()),
 
@@ -151,8 +147,8 @@ pub struct CharIterator {
 impl IterableObject for CharIterator {
     fn iterate<R>(
         &self,
-        callback: impl FnOnce(&mut dyn Iterator<Item = Value>) -> ExpressionResult<R>,
-    ) -> ExpressionResult<R> {
+        callback: impl FnOnce(&mut dyn Iterator<Item = Value>) -> ExecutionResult<R>,
+    ) -> ExecutionResult<R> {
         let mut iter = self
             .string
             .0
@@ -171,8 +167,8 @@ pub struct LineIterator {
 impl IterableObject for LineIterator {
     fn iterate<R>(
         &self,
-        callback: impl FnOnce(&mut dyn Iterator<Item = Value>) -> ExpressionResult<R>,
-    ) -> ExpressionResult<R> {
+        callback: impl FnOnce(&mut dyn Iterator<Item = Value>) -> ExecutionResult<R>,
+    ) -> ExecutionResult<R> {
         let mut iterator = self
             .string
             .0
@@ -215,11 +211,7 @@ fn register_format_method(database: &mut BuiltinCallableDatabase) {
     }
 
     impl BuiltinCallable for BuiltFunction {
-        fn call(
-            &self,
-            context: &ExecutionContext,
-            argument: Dictionary,
-        ) -> ExpressionResult<Value> {
+        fn call(&self, context: &ExecutionContext, argument: Dictionary) -> ExecutionResult<Value> {
             let this = context
                 .get_variable(LocatedStr {
                     location: context.stack_trace.bottom().clone(),

--- a/interpreter/src/execution/values/string/mod.rs
+++ b/interpreter/src/execution/values/string/mod.rs
@@ -79,7 +79,7 @@ impl Object for IString {
     }
 
     fn eq(self, context: &ExecutionContext, rhs: Value) -> ExecutionResult<bool> {
-        let rhs: &Self = rhs.downcast_for_binary_op_ref(context.stack_trace)?;
+        let rhs: &Self = rhs.downcast_for_binary_op_ref(context)?;
         Ok(self.0 == rhs.0)
     }
 
@@ -217,7 +217,7 @@ fn register_format_method(database: &mut BuiltinCallableDatabase) {
                     location: context.stack_trace.bottom().clone(),
                     string: "self",
                 })?
-                .downcast_ref::<IString>(context.stack_trace)?
+                .downcast_ref::<IString>(context)?
                 .clone();
 
             let (excess, format) = Format::parse(&this.0).map_err(|error| {
@@ -354,7 +354,7 @@ pub fn register_methods(database: &mut BuiltinCallableDatabase) {
                         "c".into(),
                         IString(ImString::from(format!("{c}"))).into()
                     )
-                ])))?.downcast::<Boolean>(context.stack_trace)?;
+                ])))?.downcast::<Boolean>(context)?;
 
                 if retain.0 {
                     product.push(c);

--- a/interpreter/src/execution/values/string/mod.rs
+++ b/interpreter/src/execution/values/string/mod.rs
@@ -23,7 +23,7 @@ use imstr::ImString;
 use crate::{
     build_closure_type, build_method,
     execution::{
-        errors::{GenericFailure, Raise},
+        errors::{Raise, StringError},
         logging::{LocatedStr, LogLevel, LogMessage},
         stack::ScopeType,
         values::{
@@ -221,7 +221,7 @@ fn register_format_method(database: &mut BuiltinCallableDatabase) {
                 .clone();
 
             let (excess, format) = Format::parse(&this.0).map_err(|error| {
-                GenericFailure(format!("Failed to parse formatting string: {error:?}").into())
+                StringError(format!("Failed to parse formatting string: {error:?}"))
                     .to_error(context.stack_trace)
             })?;
             assert!(excess.is_empty());
@@ -414,13 +414,15 @@ pub fn register_methods(database: &mut BuiltinCallableDatabase) {
             this: IString
         ) -> Scalar {
             let value = this.0.parse::<Float>()
-                .map_err(|error| GenericFailure(format!("Failed to parse scalar value: {error:?}").into()).to_error(context.stack_trace))?;
+                .map_err(|error| StringError(format!("Failed to parse scalar value: {error:?}")).to_error(context.stack_trace))?;
             Ok(Scalar {
                 dimension: Dimension::zero(),
                 value,
             })
         }
     );
+    // TODO these don't need to be formated using format!, we can use context to add the context.
+    let remember_me = 0;
     build_method!(
         database,
         methods::ParseUnsignedInteger, "String::parse_unsigned_integer",(
@@ -428,7 +430,7 @@ pub fn register_methods(database: &mut BuiltinCallableDatabase) {
             this: IString
         ) -> UnsignedInteger {
             let value = this.0.parse::<u64>()
-                .map_err(|error| GenericFailure(format!("Failed to parse unsigned integer: {error:?}").into()).to_error(context.stack_trace))?;
+                .map_err(|error| StringError(format!("Failed to parse unsigned integer: {error:?}")).to_error(context.stack_trace))?;
             Ok(UnsignedInteger::from(value))
         }
     );
@@ -439,7 +441,7 @@ pub fn register_methods(database: &mut BuiltinCallableDatabase) {
             this: IString
         ) -> SignedInteger {
             let value = this.0.parse::<i64>()
-                .map_err(|error| GenericFailure(format!("Failed to parse signed integer: {error:?}").into()).to_error(context.stack_trace))?;
+                .map_err(|error| StringError(format!("Failed to parse signed integer: {error:?}")).to_error(context.stack_trace))?;
             Ok(SignedInteger::from(value))
         }
     );

--- a/interpreter/src/execution/values/string/mod.rs
+++ b/interpreter/src/execution/values/string/mod.rs
@@ -113,7 +113,7 @@ impl Object for IString {
             _ => Err(MissingAttributeError {
                 name: attribute.into(),
             }
-            .to_error(context.stack_trace)),
+            .to_error(context)),
         }
     }
 }
@@ -222,7 +222,7 @@ fn register_format_method(database: &mut BuiltinCallableDatabase) {
 
             let (excess, format) = Format::parse(&this.0).map_err(|error| {
                 StringError(format!("Failed to parse formatting string: {error:?}"))
-                    .to_error(context.stack_trace)
+                    .to_error(context)
             })?;
             assert!(excess.is_empty());
 
@@ -414,7 +414,7 @@ pub fn register_methods(database: &mut BuiltinCallableDatabase) {
             this: IString
         ) -> Scalar {
             let value = this.0.parse::<Float>()
-                .map_err(|error| StringError(format!("Failed to parse scalar value: {error:?}")).to_error(context.stack_trace))?;
+                .map_err(|error| StringError(format!("Failed to parse scalar value: {error:?}")).to_error(context))?;
             Ok(Scalar {
                 dimension: Dimension::zero(),
                 value,
@@ -430,7 +430,7 @@ pub fn register_methods(database: &mut BuiltinCallableDatabase) {
             this: IString
         ) -> UnsignedInteger {
             let value = this.0.parse::<u64>()
-                .map_err(|error| StringError(format!("Failed to parse unsigned integer: {error:?}")).to_error(context.stack_trace))?;
+                .map_err(|error| StringError(format!("Failed to parse unsigned integer: {error:?}")).to_error(context))?;
             Ok(UnsignedInteger::from(value))
         }
     );
@@ -441,7 +441,7 @@ pub fn register_methods(database: &mut BuiltinCallableDatabase) {
             this: IString
         ) -> SignedInteger {
             let value = this.0.parse::<i64>()
-                .map_err(|error| StringError(format!("Failed to parse signed integer: {error:?}")).to_error(context.stack_trace))?;
+                .map_err(|error| StringError(format!("Failed to parse signed integer: {error:?}")).to_error(context))?;
             Ok(SignedInteger::from(value))
         }
     );

--- a/interpreter/src/execution/values/string/mod.rs
+++ b/interpreter/src/execution/values/string/mod.rs
@@ -220,10 +220,17 @@ fn register_format_method(database: &mut BuiltinCallableDatabase) {
                 .downcast_ref::<IString>(context)?
                 .clone();
 
-            let (excess, format) = Format::parse(&this.0).map_err(|error| {
-                StringError(format!("Failed to parse formatting string: {error:?}"))
-                    .to_error(context)
-            })?;
+            let (excess, format) = context.trace_scope(
+                Some("".into()),
+                context.stack_trace.bottom().clone(),
+                |_context| {
+                    // The error message of this type is dependent on the lifetime of `this`, so we
+                    // encode it to a string to make the lifetime static.
+                    Format::parse(&this.0)
+                        .map_err(|error| StringError(format!("{error:?}")).to_error(context))
+                },
+            )?;
+
             assert!(excess.is_empty());
 
             let mut output = String::new();
@@ -413,25 +420,27 @@ pub fn register_methods(database: &mut BuiltinCallableDatabase) {
             context: &ExecutionContext,
             this: IString
         ) -> Scalar {
-            let value = this.0.parse::<Float>()
-                .map_err(|error| StringError(format!("Failed to parse scalar value: {error:?}")).to_error(context))?;
-            Ok(Scalar {
-                dimension: Dimension::zero(),
-                value,
+            context.trace_scope(Some("Failed to parse scalar value".into()), context.stack_trace.bottom().clone(), |context| {
+                let value = this.0.parse::<Float>()
+                    .map_err(|error| error.to_error(context))?;
+                Ok(Scalar {
+                    dimension: Dimension::zero(),
+                    value,
+                })
             })
         }
     );
-    // TODO these don't need to be formated using format!, we can use context to add the context.
-    let remember_me = 0;
     build_method!(
         database,
         methods::ParseUnsignedInteger, "String::parse_unsigned_integer",(
             context: &ExecutionContext,
             this: IString
         ) -> UnsignedInteger {
-            let value = this.0.parse::<u64>()
-                .map_err(|error| StringError(format!("Failed to parse unsigned integer: {error:?}")).to_error(context))?;
-            Ok(UnsignedInteger::from(value))
+            context.trace_scope(Some("Failed to parse unsigned integer".into()), context.stack_trace.bottom().clone(), |context| {
+                let value = this.0.parse::<u64>()
+                    .map_err(|error| error.to_error(context))?;
+                Ok(UnsignedInteger::from(value))
+            })
         }
     );
     build_method!(
@@ -440,9 +449,11 @@ pub fn register_methods(database: &mut BuiltinCallableDatabase) {
             context: &ExecutionContext,
             this: IString
         ) -> SignedInteger {
-            let value = this.0.parse::<i64>()
-                .map_err(|error| StringError(format!("Failed to parse signed integer: {error:?}")).to_error(context))?;
-            Ok(SignedInteger::from(value))
+            context.trace_scope(Some("Failed to parse signed integer".into()), context.stack_trace.bottom().clone(), |context| {
+                let value = this.0.parse::<i64>()
+                    .map_err(|error| error.to_error(context))?;
+                Ok(SignedInteger::from(value))
+            })
         }
     );
     build_method!(

--- a/interpreter/src/execution/values/value_type.rs
+++ b/interpreter/src/execution/values/value_type.rs
@@ -252,7 +252,7 @@ impl Object for ValueType {
             _ => Err(MissingAttributeError {
                 name: attribute.into(),
             }
-            .to_error(context.stack_trace)),
+            .to_error(context)),
         }
     }
 }
@@ -276,7 +276,7 @@ pub fn register_methods(database: &mut BuiltinCallableDatabase) {
             this: ValueType,
             to_qualify: Value) -> ValueNone
         {
-            this.check_other_qualifies(&to_qualify.get_type(context)).map_err(|error| error.to_error(context.stack_trace))?;
+            this.check_other_qualifies(&to_qualify.get_type(context)).map_err(|error| error.to_error(context))?;
             Ok(values::ValueNone)
         }
     );

--- a/interpreter/src/execution/values/value_type.rs
+++ b/interpreter/src/execution/values/value_type.rs
@@ -31,7 +31,7 @@ use crate::{
     compile::{self, AstNode},
     execute_expression,
     execution::{
-        errors::{ErrorType, ExecutionResult, Raise},
+        errors::{ExecutionResult, Raise},
         logging::{LogLevel, LogMessage},
         values::{
             self, closure::BuiltinCallableDatabase, dictionary::DictionaryData,
@@ -514,7 +514,7 @@ impl TypeQualificationError {
     }
 }
 
-impl ErrorType for TypeQualificationError {}
+impl std::error::Error for TypeQualificationError {}
 
 impl Display for TypeQualificationError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/interpreter/src/execution/values/value_type.rs
+++ b/interpreter/src/execution/values/value_type.rs
@@ -31,7 +31,7 @@ use crate::{
     compile::{self, AstNode},
     execute_expression,
     execution::{
-        errors::{ErrorType, ExpressionResult, Raise},
+        errors::{ErrorType, ExecutionResult, Raise},
         logging::{LogLevel, LogMessage},
         values::{
             self, closure::BuiltinCallableDatabase, dictionary::DictionaryData,
@@ -239,17 +239,13 @@ impl Object for ValueType {
         write!(f, "{}", self)
     }
 
-    fn bit_or(self, context: &ExecutionContext, rhs: Value) -> ExpressionResult<Value> {
+    fn bit_or(self, context: &ExecutionContext, rhs: Value) -> ExecutionResult<Value> {
         let rhs: Self = rhs.downcast_for_binary_op(context.stack_trace)?;
 
         Ok(self.merge(rhs).into())
     }
 
-    fn get_attribute(
-        &self,
-        context: &ExecutionContext,
-        attribute: &str,
-    ) -> ExpressionResult<Value> {
+    fn get_attribute(&self, context: &ExecutionContext, attribute: &str) -> ExecutionResult<Value> {
         match attribute {
             "qualify" => Ok(BuiltinFunction::new::<methods::Qualify>().into()),
             "try_qualify" => Ok(BuiltinFunction::new::<methods::TryQualify>().into()),
@@ -307,7 +303,7 @@ impl StructMember {
     fn new(
         context: &ExecutionContext,
         source: &AstNode<compile::StructMember>,
-    ) -> ExpressionResult<Self> {
+    ) -> ExecutionResult<Self> {
         let ty = execute_expression(context, &source.node.ty)?
             .downcast::<ValueType>(context.stack_trace)?;
         let default = if let Some(default) = source.node.default.as_ref() {
@@ -340,7 +336,7 @@ impl StructDefinition {
     pub fn new(
         context: &ExecutionContext,
         source: &AstNode<compile::StructDefinition>,
-    ) -> ExpressionResult<Self> {
+    ) -> ExecutionResult<Self> {
         let mut members = HashMap::new();
         for member in source.node.members.iter() {
             let name = member.node.name.node.clone();

--- a/interpreter/src/execution/values/value_type.rs
+++ b/interpreter/src/execution/values/value_type.rs
@@ -240,7 +240,7 @@ impl Object for ValueType {
     }
 
     fn bit_or(self, context: &ExecutionContext, rhs: Value) -> ExecutionResult<Value> {
-        let rhs: Self = rhs.downcast_for_binary_op(context.stack_trace)?;
+        let rhs: Self = rhs.downcast_for_binary_op(context)?;
 
         Ok(self.merge(rhs).into())
     }
@@ -304,8 +304,7 @@ impl StructMember {
         context: &ExecutionContext,
         source: &AstNode<compile::StructMember>,
     ) -> ExecutionResult<Self> {
-        let ty = execute_expression(context, &source.node.ty)?
-            .downcast::<ValueType>(context.stack_trace)?;
+        let ty = execute_expression(context, &source.node.ty)?.downcast::<ValueType>(context)?;
         let default = if let Some(default) = source.node.default.as_ref() {
             Some(execute_expression(context, default)?)
         } else {

--- a/interpreter/src/execution/values/value_type.rs
+++ b/interpreter/src/execution/values/value_type.rs
@@ -535,9 +535,16 @@ mod test {
             .check_other_qualifies(&ValueType::TypeNone)
             .unwrap();
 
-        ValueType::TypeNone
+        let error = ValueType::TypeNone
             .check_other_qualifies(&ValueType::UnsignedInteger)
             .unwrap_err();
+        assert_eq!(
+            error,
+            TypeQualificationError::This {
+                expected: ValueType::TypeNone,
+                got: ValueType::UnsignedInteger
+            }
+        )
     }
 
     #[test]
@@ -546,9 +553,16 @@ mod test {
             .check_other_qualifies(&ValueType::Boolean)
             .unwrap();
 
-        ValueType::Boolean
+        let error = ValueType::Boolean
             .check_other_qualifies(&ValueType::TypeNone)
             .unwrap_err();
+        assert_eq!(
+            error,
+            TypeQualificationError::This {
+                expected: ValueType::Boolean,
+                got: ValueType::TypeNone
+            }
+        )
     }
 
     #[test]
@@ -557,9 +571,16 @@ mod test {
             .check_other_qualifies(&ValueType::SignedInteger)
             .unwrap();
 
-        ValueType::SignedInteger
+        let error = ValueType::SignedInteger
             .check_other_qualifies(&ValueType::TypeNone)
             .unwrap_err();
+        assert_eq!(
+            error,
+            TypeQualificationError::This {
+                expected: ValueType::SignedInteger,
+                got: ValueType::TypeNone
+            }
+        )
     }
 
     #[test]
@@ -568,9 +589,16 @@ mod test {
             .check_other_qualifies(&ValueType::UnsignedInteger)
             .unwrap();
 
-        ValueType::UnsignedInteger
+        let error = ValueType::UnsignedInteger
             .check_other_qualifies(&ValueType::TypeNone)
             .unwrap_err();
+        assert_eq!(
+            error,
+            TypeQualificationError::This {
+                expected: ValueType::UnsignedInteger,
+                got: ValueType::TypeNone
+            }
+        )
     }
 
     #[test]
@@ -583,13 +611,27 @@ mod test {
             .check_other_qualifies(&ValueType::Scalar(Some(Dimension::length())))
             .unwrap();
 
-        ValueType::Scalar(Some(Dimension::length()))
+        let error = ValueType::Scalar(Some(Dimension::length()))
             .check_other_qualifies(&ValueType::Scalar(Some(Dimension::area())))
             .unwrap_err();
+        assert_eq!(
+            error,
+            TypeQualificationError::This {
+                expected: ValueType::Scalar(Some(Dimension::length())),
+                got: ValueType::Scalar(Some(Dimension::area())),
+            }
+        );
 
-        ValueType::Scalar(Some(Dimension::length()))
+        let error = ValueType::Scalar(Some(Dimension::length()))
             .check_other_qualifies(&ValueType::TypeNone)
             .unwrap_err();
+        assert_eq!(
+            error,
+            TypeQualificationError::This {
+                expected: ValueType::Scalar(Some(Dimension::length())),
+                got: ValueType::TypeNone
+            }
+        );
     }
 
     #[test]
@@ -602,13 +644,27 @@ mod test {
             .check_other_qualifies(&ValueType::Vector2(Some(Dimension::length())))
             .unwrap();
 
-        ValueType::Vector2(Some(Dimension::length()))
+        let error = ValueType::Vector2(Some(Dimension::length()))
             .check_other_qualifies(&ValueType::Vector2(Some(Dimension::area())))
             .unwrap_err();
+        assert_eq!(
+            error,
+            TypeQualificationError::This {
+                expected: ValueType::Vector2(Some(Dimension::length())),
+                got: ValueType::Vector2(Some(Dimension::area())),
+            }
+        );
 
-        ValueType::Vector2(Some(Dimension::length()))
+        let error = ValueType::Vector2(Some(Dimension::length()))
             .check_other_qualifies(&ValueType::TypeNone)
             .unwrap_err();
+        assert_eq!(
+            error,
+            TypeQualificationError::This {
+                expected: ValueType::Vector2(Some(Dimension::length())),
+                got: ValueType::TypeNone
+            }
+        );
     }
 
     #[test]
@@ -621,13 +677,27 @@ mod test {
             .check_other_qualifies(&ValueType::Vector3(Some(Dimension::length())))
             .unwrap();
 
-        ValueType::Vector3(Some(Dimension::length()))
+        let error = ValueType::Vector3(Some(Dimension::length()))
             .check_other_qualifies(&ValueType::Vector3(Some(Dimension::area())))
             .unwrap_err();
+        assert_eq!(
+            error,
+            TypeQualificationError::This {
+                expected: ValueType::Vector3(Some(Dimension::length())),
+                got: ValueType::Vector3(Some(Dimension::area())),
+            }
+        );
 
-        ValueType::Vector3(Some(Dimension::length()))
+        let error = ValueType::Vector3(Some(Dimension::length()))
             .check_other_qualifies(&ValueType::TypeNone)
             .unwrap_err();
+        assert_eq!(
+            error,
+            TypeQualificationError::This {
+                expected: ValueType::Vector3(Some(Dimension::length())),
+                got: ValueType::TypeNone
+            }
+        );
     }
 
     #[test]
@@ -640,13 +710,27 @@ mod test {
             .check_other_qualifies(&ValueType::Vector4(Some(Dimension::length())))
             .unwrap();
 
-        ValueType::Vector4(Some(Dimension::length()))
+        let error = ValueType::Vector4(Some(Dimension::length()))
             .check_other_qualifies(&ValueType::Vector4(Some(Dimension::area())))
             .unwrap_err();
+        assert_eq!(
+            error,
+            TypeQualificationError::This {
+                expected: ValueType::Vector4(Some(Dimension::length())),
+                got: ValueType::Vector4(Some(Dimension::area())),
+            }
+        );
 
-        ValueType::Vector4(Some(Dimension::length()))
+        let error = ValueType::Vector4(Some(Dimension::length()))
             .check_other_qualifies(&ValueType::TypeNone)
             .unwrap_err();
+        assert_eq!(
+            error,
+            TypeQualificationError::This {
+                expected: ValueType::Vector4(Some(Dimension::length())),
+                got: ValueType::TypeNone
+            }
+        );
     }
 
     #[test]
@@ -717,9 +801,22 @@ mod test {
             let dictionary = test_run("(a = std.consts.None, b = std.consts.None)").unwrap();
             let dictionary = dictionary.as_dictionary().unwrap();
 
-            structure
+            let error = structure
                 .check_other_qualifies(&dictionary.get_type(context))
                 .unwrap_err();
+            dbg!(&error);
+            assert_eq!(
+                error,
+                TypeQualificationError::Fields {
+                    failed_feilds: vec![MissmatchedField {
+                        name: "b".into(),
+                        error: TypeQualificationError::This {
+                            expected: ValueType::TypeNone,
+                            got: ValueType::TypeNone
+                        }
+                    }]
+                }
+            );
         })
     }
 
@@ -759,9 +856,16 @@ mod test {
             .check_other_qualifies(&ValueType::ValueType)
             .unwrap();
 
-        ValueType::UnsignedInteger
+        let error = ValueType::ValueType
             .check_other_qualifies(&ValueType::TypeNone)
             .unwrap_err();
+        assert_eq!(
+            error,
+            TypeQualificationError::This {
+                expected: ValueType::ValueType,
+                got: ValueType::TypeNone
+            }
+        );
     }
 
     #[test]
@@ -777,9 +881,16 @@ mod test {
             .check_other_qualifies(&ValueType::UnsignedInteger)
             .unwrap();
 
-        value_type
+        let error = value_type
             .check_other_qualifies(&ValueType::SignedInteger)
             .unwrap_err();
+        assert_eq!(
+            error,
+            TypeQualificationError::This {
+                expected: value_type.clone(),
+                got: ValueType::SignedInteger
+            }
+        );
     }
 
     #[test]
@@ -799,9 +910,16 @@ mod test {
             .check_other_qualifies(&ValueType::SignedInteger)
             .unwrap();
 
-        value_type
+        let error = value_type
             .check_other_qualifies(&ValueType::Boolean)
             .unwrap_err();
+        assert_eq!(
+            error,
+            TypeQualificationError::This {
+                expected: value_type.clone(),
+                got: ValueType::Boolean
+            }
+        );
     }
 
     #[test]
@@ -861,6 +979,15 @@ mod test {
         let result = test_run("std.types.Bool::qualify(to_qualify = true)").unwrap();
         assert_eq!(result, values::ValueNone.into());
 
-        test_run("std.types.Bool::qualify(to_qualify = 5u)").unwrap_err();
+        let error = test_run("std.types.Bool::qualify(to_qualify = 5u)").unwrap_err();
+        let error = error.ty.as_any();
+        let error: &TypeQualificationError = error.downcast_ref().unwrap();
+        assert_eq!(
+            *error,
+            TypeQualificationError::This {
+                expected: ValueType::Boolean,
+                got: ValueType::UnsignedInteger
+            }
+        );
     }
 }

--- a/interpreter/src/execution/values/vector.rs
+++ b/interpreter/src/execution/values/vector.rs
@@ -7,7 +7,7 @@ use crate::{
     compile::{self, AstNode},
     execute_expression,
     execution::{
-        errors::{ExecutionResult, GenericFailure, Raise as _},
+        errors::{ExecutionResult, Raise as _, StrError},
         logging::StackTrace,
         values::{
             closure::BuiltinCallableDatabase, scalar::UnwrapNotNan, string::formatting::Style,
@@ -207,10 +207,7 @@ where
         if !value.is_nan() {
             Ok(Self { dimension, value })
         } else {
-            Err(
-                GenericFailure("Result of arithmetic operation is NaN".into())
-                    .to_error(context.stack_trace),
-            )
+            Err(StrError("Result of arithmetic operation is NaN").to_error(context.stack_trace))
         }
     }
 
@@ -262,7 +259,10 @@ mod methods {
     use super::*;
     use crate::{
         build_method,
-        execution::values::{BuiltinCallableDatabase, Dictionary},
+        execution::{
+            errors::StrError,
+            values::{BuiltinCallableDatabase, Dictionary},
+        },
     };
 
     pub trait MethodSet {
@@ -468,7 +468,7 @@ mod methods {
 
                 for component in result.iter() {
                     if component.dimension != dimension {
-                        return Err(GenericFailure("All components of a vector must match".into())
+                        return Err(StrError("All components of a vector must match")
                             .to_error(context.stack_trace));
                     }
                 }
@@ -630,10 +630,7 @@ impl VectorInternalType for nalgebra::Vector2<Float> {
                 value: Self::new(*x.value, *y.value),
             })
         } else {
-            Err(
-                GenericFailure("All components of a vector must match".into())
-                    .to_error(context.stack_trace),
-            )
+            Err(StrError("All components of a vector must match").to_error(context.stack_trace))
         }
     }
 
@@ -755,10 +752,7 @@ impl VectorInternalType for nalgebra::Vector3<Float> {
                 value: Self::new(*x.value, *y.value, *z.value),
             })
         } else {
-            Err(
-                GenericFailure("All components of a vector must match".into())
-                    .to_error(context.stack_trace),
-            )
+            Err(StrError("All components of a vector must match").to_error(context.stack_trace))
         }
     }
 
@@ -891,10 +885,7 @@ impl VectorInternalType for nalgebra::Vector4<Float> {
                 value: Self::new(*x.value, *y.value, *z.value, *w.value),
             })
         } else {
-            Err(
-                GenericFailure("All components of a vector must match".into())
-                    .to_error(context.stack_trace),
-            )
+            Err(StrError("All components of a vector must match").to_error(context.stack_trace))
         }
     }
 

--- a/interpreter/src/execution/values/vector.rs
+++ b/interpreter/src/execution/values/vector.rs
@@ -170,7 +170,7 @@ where
                 _ => Err(MissingAttributeError {
                     name: attribute.into(),
                 }
-                .to_error(context.stack_trace)),
+                .to_error(context)),
             }
         }
     }
@@ -207,7 +207,7 @@ where
         if !value.is_nan() {
             Ok(Self { dimension, value })
         } else {
-            Err(StrError("Result of arithmetic operation is NaN").to_error(context.stack_trace))
+            Err(StrError("Result of arithmetic operation is NaN").to_error(context))
         }
     }
 
@@ -350,7 +350,7 @@ mod methods {
                         expected: this.type_name(),
                         got: value.type_name(),
                     }
-                    .to_error(context.stack_trace))
+                    .to_error(context))
                 }
             }
         );
@@ -401,7 +401,7 @@ mod methods {
                         expected: this.type_name(),
                         got: rhs.type_name(),
                     }
-                    .to_error(context.stack_trace))
+                    .to_error(context))
                 }
             }
         );
@@ -469,7 +469,7 @@ mod methods {
                 for component in result.iter() {
                     if component.dimension != dimension {
                         return Err(StrError("All components of a vector must match")
-                            .to_error(context.stack_trace));
+                            .to_error(context));
                     }
                 }
 
@@ -528,7 +528,7 @@ pub fn register_methods(database: &mut BuiltinCallableDatabase) {
                     expected: this.type_name(),
                     got: rhs.type_name(),
                 }
-                .to_error(context.stack_trace))
+                .to_error(context))
             }
         }
     );
@@ -630,7 +630,7 @@ impl VectorInternalType for nalgebra::Vector2<Float> {
                 value: Self::new(*x.value, *y.value),
             })
         } else {
-            Err(StrError("All components of a vector must match").to_error(context.stack_trace))
+            Err(StrError("All components of a vector must match").to_error(context))
         }
     }
 
@@ -752,7 +752,7 @@ impl VectorInternalType for nalgebra::Vector3<Float> {
                 value: Self::new(*x.value, *y.value, *z.value),
             })
         } else {
-            Err(StrError("All components of a vector must match").to_error(context.stack_trace))
+            Err(StrError("All components of a vector must match").to_error(context))
         }
     }
 
@@ -885,7 +885,7 @@ impl VectorInternalType for nalgebra::Vector4<Float> {
                 value: Self::new(*x.value, *y.value, *z.value, *w.value),
             })
         } else {
-            Err(StrError("All components of a vector must match").to_error(context.stack_trace))
+            Err(StrError("All components of a vector must match").to_error(context))
         }
     }
 

--- a/interpreter/src/execution/values/vector.rs
+++ b/interpreter/src/execution/values/vector.rs
@@ -7,7 +7,7 @@ use crate::{
     compile::{self, AstNode},
     execute_expression,
     execution::{
-        errors::{ExecutionResult, Raise as _, StrError},
+        errors::{ExecutionResult, Raise as _},
         values::{
             closure::BuiltinCallableDatabase, scalar::UnwrapNotNan, string::formatting::Style,
             BuiltinFunction, DowncastForBinaryOpError, MissingAttributeError, Object, Scalar,
@@ -15,6 +15,7 @@ use crate::{
         },
         ExecutionContext,
     },
+    values::scalar::ResultIsNan,
 };
 
 use std::{
@@ -206,7 +207,7 @@ where
         if !value.is_nan() {
             Ok(Self { dimension, value })
         } else {
-            Err(StrError("Result of arithmetic operation is NaN").to_error(context))
+            Err(ResultIsNan.to_error(context))
         }
     }
 
@@ -262,10 +263,7 @@ mod methods {
     use super::*;
     use crate::{
         build_method,
-        execution::{
-            errors::StrError,
-            values::{BuiltinCallableDatabase, Dictionary},
-        },
+        execution::values::{BuiltinCallableDatabase, Dictionary},
     };
 
     pub trait MethodSet {
@@ -471,7 +469,7 @@ mod methods {
 
                 for component in result.iter() {
                     if component.dimension != dimension {
-                        return Err(StrError("All components of a vector must match")
+                        return Err(MissmatchedComponentDimensionsError
                             .to_error(context));
                     }
                 }
@@ -600,6 +598,17 @@ where
     }
 }
 
+#[derive(Debug, Eq, PartialEq)]
+pub struct MissmatchedComponentDimensionsError;
+
+impl std::error::Error for MissmatchedComponentDimensionsError {}
+
+impl std::fmt::Display for MissmatchedComponentDimensionsError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "All components of a vector must match")
+    }
+}
+
 macro_rules! get_component {
     ($context:ident, $ast_node:ident, $c:ident) => {
         execute_expression($context, &$ast_node.node.$c)?.downcast::<Scalar>($context)?
@@ -632,7 +641,7 @@ impl VectorInternalType for nalgebra::Vector2<Float> {
                 value: Self::new(*x.value, *y.value),
             })
         } else {
-            Err(StrError("All components of a vector must match").to_error(context))
+            Err(MissmatchedComponentDimensionsError.to_error(context))
         }
     }
 
@@ -752,7 +761,7 @@ impl VectorInternalType for nalgebra::Vector3<Float> {
                 value: Self::new(*x.value, *y.value, *z.value),
             })
         } else {
-            Err(StrError("All components of a vector must match").to_error(context))
+            Err(MissmatchedComponentDimensionsError.to_error(context))
         }
     }
 
@@ -882,7 +891,7 @@ impl VectorInternalType for nalgebra::Vector4<Float> {
                 value: Self::new(*x.value, *y.value, *z.value, *w.value),
             })
         } else {
-            Err(StrError("All components of a vector must match").to_error(context))
+            Err(MissmatchedComponentDimensionsError.to_error(context))
         }
     }
 
@@ -1122,23 +1131,65 @@ mod test {
 
     #[test]
     fn missmatched_dimensions_vector2() {
-        test_run("<(1deg, 2m)>").unwrap_err();
-        test_run("<(1m, 2deg)>").unwrap_err();
+        let error = test_run("<(1deg, 2m)>").unwrap_err();
+        let error = error.ty.as_any();
+        error
+            .downcast_ref::<MissmatchedComponentDimensionsError>()
+            .unwrap();
+
+        let error = test_run("<(1m, 2deg)>").unwrap_err();
+        let error = error.ty.as_any();
+        error
+            .downcast_ref::<MissmatchedComponentDimensionsError>()
+            .unwrap();
     }
 
     #[test]
     fn missmatched_dimensions_vector3() {
-        test_run("<(1deg, 2m, 3m)>").unwrap_err();
-        test_run("<(1m, 2deg, 3m)>").unwrap_err();
-        test_run("<(1m, 2m, 3deg)>").unwrap_err();
+        let error = test_run("<(1deg, 2m, 3m)>").unwrap_err();
+        let error = error.ty.as_any();
+        error
+            .downcast_ref::<MissmatchedComponentDimensionsError>()
+            .unwrap();
+
+        let error = test_run("<(1m, 2deg, 3m)>").unwrap_err();
+        let error = error.ty.as_any();
+        error
+            .downcast_ref::<MissmatchedComponentDimensionsError>()
+            .unwrap();
+
+        let error = test_run("<(1m, 2m, 3deg)>").unwrap_err();
+        let error = error.ty.as_any();
+        error
+            .downcast_ref::<MissmatchedComponentDimensionsError>()
+            .unwrap();
     }
 
     #[test]
     fn missmatched_dimensions_vector4() {
-        test_run("<(1deg, 2m, 3m, 4m)>").unwrap_err();
-        test_run("<(1m, 2deg, 3m, 4m)>").unwrap_err();
-        test_run("<(1m, 2m, 3deg, 4m)>").unwrap_err();
-        test_run("<(1m, 2m, 3m, 4deg)>").unwrap_err();
+        let error = test_run("<(1deg, 2m, 3m, 4m)>").unwrap_err();
+        let error = error.ty.as_any();
+        error
+            .downcast_ref::<MissmatchedComponentDimensionsError>()
+            .unwrap();
+
+        let error = test_run("<(1m, 2deg, 3m, 4m)>").unwrap_err();
+        let error = error.ty.as_any();
+        error
+            .downcast_ref::<MissmatchedComponentDimensionsError>()
+            .unwrap();
+        let error = test_run("<(1m, 2m, 3deg, 4m)>").unwrap_err();
+
+        let error = error.ty.as_any();
+        error
+            .downcast_ref::<MissmatchedComponentDimensionsError>()
+            .unwrap();
+
+        let error = test_run("<(1m, 2m, 3m, 4deg)>").unwrap_err();
+        let error = error.ty.as_any();
+        error
+            .downcast_ref::<MissmatchedComponentDimensionsError>()
+            .unwrap();
     }
 
     #[test]
@@ -1489,17 +1540,23 @@ mod test {
 
     #[test]
     fn normalize_zero_vector2() {
-        test_run("<(0m, 0m)>::normalize()").unwrap_err();
+        let error = test_run("<(0m, 0m)>::normalize()").unwrap_err();
+        let error = error.ty.as_any();
+        error.downcast_ref::<ResultIsNan>().unwrap();
     }
 
     #[test]
     fn normalize_zero_vector3() {
-        test_run("<(0m, 0m, 0m)>::normalize()").unwrap_err();
+        let error = test_run("<(0m, 0m, 0m)>::normalize()").unwrap_err();
+        let error = error.ty.as_any();
+        error.downcast_ref::<ResultIsNan>().unwrap();
     }
 
     #[test]
     fn normalize_zero_vector4() {
-        test_run("<(0m, 0m, 0m, 0m)>::normalize()").unwrap_err();
+        let error = test_run("<(0m, 0m, 0m, 0m)>::normalize()").unwrap_err();
+        let error = error.ty.as_any();
+        error.downcast_ref::<ResultIsNan>().unwrap();
     }
 
     #[test]
@@ -1538,7 +1595,11 @@ mod test {
         let product = test_run("<(0m, 1m)>::apply(f = (c: std.scalar.Length) -> std.scalar.Area: c * 1m) == <(0 'm^2', 1 'm^2')>").unwrap();
         assert_eq!(product, Boolean(true).into());
 
-        test_run("<(0m, 1m)>::apply(f = (c: std.scalar.Length) -> std.scalar.Any: if c == 0m then 1m else 1 'm^2')").unwrap_err();
+        let error = test_run("<(0m, 1m)>::apply(f = (c: std.scalar.Length) -> std.scalar.Any: if c == 0m then 1m else 1 'm^2')").unwrap_err();
+        let error = error.ty.as_any();
+        error
+            .downcast_ref::<MissmatchedComponentDimensionsError>()
+            .unwrap();
     }
 
     #[test]
@@ -1549,7 +1610,11 @@ mod test {
         let product = test_run("<(0m, 1m, 2m)>::apply(f = (c: std.scalar.Length) -> std.scalar.Area: c * 1m) == <(0 'm^2', 1 'm^2', 2 'm^2')>").unwrap();
         assert_eq!(product, Boolean(true).into());
 
-        test_run("<(0m, 1m, 1m)>::apply(f = (c: std.scalar.Length) -> std.scalar.Any: if c == 0m then 1m else 1 'm^2')").unwrap_err();
+        let error =test_run("<(0m, 1m, 1m)>::apply(f = (c: std.scalar.Length) -> std.scalar.Any: if c == 0m then 1m else 1 'm^2')").unwrap_err();
+        let error = error.ty.as_any();
+        error
+            .downcast_ref::<MissmatchedComponentDimensionsError>()
+            .unwrap();
     }
 
     #[test]
@@ -1560,7 +1625,11 @@ mod test {
         let product = test_run("<(0m, 1m, 2m, 3m)>::apply(f = (c: std.scalar.Length) -> std.scalar.Area: c * 1m) == <(0 'm^2', 1 'm^2', 2 'm^2', 3 'm^2')>").unwrap();
         assert_eq!(product, Boolean(true).into());
 
-        test_run("<(0m, 1m, 1m, 1m)>::apply(f = (c: std.scalar.Length) -> std.scalar.Any: if c == 0m then 1m else 1 'm^2')").unwrap_err();
+        let error = test_run("<(0m, 1m, 1m, 1m)>::apply(f = (c: std.scalar.Length) -> std.scalar.Any: if c == 0m then 1m else 1 'm^2')").unwrap_err();
+        let error = error.ty.as_any();
+        error
+            .downcast_ref::<MissmatchedComponentDimensionsError>()
+            .unwrap();
     }
 
     #[test]

--- a/interpreter/src/execution/values/void.rs
+++ b/interpreter/src/execution/values/void.rs
@@ -63,7 +63,7 @@ impl Object for ValueNone {
         write!(f, "None")
     }
 
-    fn eq(self, _context: &ExecutionContext, rhs: Value) -> crate::ExpressionResult<bool> {
+    fn eq(self, _context: &ExecutionContext, rhs: Value) -> crate::ExecutionResult<bool> {
         Ok(matches!(rhs, Value::ValueNone(_)))
     }
 }

--- a/interpreter/src/lib.rs
+++ b/interpreter/src/lib.rs
@@ -22,7 +22,7 @@ pub mod execution;
 pub use compile::{compile, new_parser, Parser, SourceReference};
 pub use execution::{
     build_prelude, execute_expression, run_file, values, Error, ExecutionContext,
-    ExecutionFileCache, ExpressionResult, LogLevel, LogMessage, RuntimeLog, StackScope, StackTrace,
+    ExecutionFileCache, ExecutionResult, LogLevel, LogMessage, RuntimeLog, StackScope, StackTrace,
     Store,
 };
 pub use imstr::ImString;


### PR DESCRIPTION
General improvements to error messages

<img width="946" height="467" alt="image" src="https://github.com/user-attachments/assets/4b71b184-41b4-432a-88f3-937169fe8293" />

* Generally cleaner interface for converting general errors into execution errors
* Stack scopes can have error context added to them, so that you can have more context of what you were trying to do when things went wrong
* Duplicate scopes are now de-duplicated, making for cleaner stack traces
* Errors are now downcasted and their types verified for unit tests that are expected to fail
* All of this extra context is now reflected in the cli

I do think that the presentation of error messages could be generally better, but the API bits are all here so that can be pushed off to later.