### PR TITLE
Get back on the main branch of fenix

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -23,16 +23,15 @@
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1771385326,
-        "narHash": "sha256-SI3IR8gdoIL21Ur7yfLY1Wd7MC48iqsthY0Adxzb/Bg=",
+        "lastModified": 1772348640,
+        "narHash": "sha256-caiKs7O4khFydpKyg8O8/nmvw/NfN4fn/4spageGoig=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "6ef197384c418654c34d2819d06a80f660881486",
+        "rev": "47c5355eaba0b08836e720d5d545c8ea1e1783db",
         "type": "github"
       },
       "original": {
         "owner": "nix-community",
-        "ref": "eureka-cpu/rust-analyzer-wrapped",
         "repo": "fenix",
         "type": "github"
       }
@@ -82,11 +81,11 @@
     "rust-analyzer-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1771264911,
-        "narHash": "sha256-vDNZ6Y1M3DSa1JbPGgqtdJPl4rMzxebUK9hmZcopxX0=",
+        "lastModified": 1772310333,
+        "narHash": "sha256-njFwHnxYcfQINwSa+XWhenv8s8PMg/j5ID0HpIa49xM=",
         "owner": "rust-lang",
         "repo": "rust-analyzer",
-        "rev": "3360aebb35a099ff4a7bbd37e9a0dd44b8f23748",
+        "rev": "a96b6a9b887008bae01839543f9ca8e1f67f4ebe",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -6,8 +6,7 @@
     flake-utils.url  = "github:numtide/flake-utils";
     crane.url = "github:ipetkov/crane";
     fenix = {
-      # url = "github:nix-community/fenix";
-      url = "github:nix-community/fenix?ref=eureka-cpu/rust-analyzer-wrapped";
+      url = "github:nix-community/fenix";
       inputs.nixpkgs.follows = "nixpkgs";
     };
   };
@@ -56,7 +55,6 @@
         };
 
         devShells.default = with pkgs; pkgs.mkShell {
-          inputsFrom = [ packages.default ];
           buildInputs = [
 	    bashInteractive
 	    nodejs_24


### PR DESCRIPTION
As discussed here, https://github.com/IamTheCarl/CommandCAD/pull/15#issuecomment-3978196488 we do not need a special branch to use rust-analyzer.

This PR fixes that.